### PR TITLE
Fix Elasticache latency unit

### DIFF
--- a/modules/aws/apigateway_cloudwatch.hcl
+++ b/modules/aws/apigateway_cloudwatch.hcl
@@ -52,6 +52,7 @@ ingester aws_apigateway_cloudwatch module {
     unit         = "ms"
     aggregator   = "PERCENTILE"
     error_margin = 0.05
+    multiplier   = 1
 
     source cloudwatch "throughput" {
       query {

--- a/modules/aws/elasticache_cloudwatch.hcl
+++ b/modules/aws/elasticache_cloudwatch.hcl
@@ -80,8 +80,9 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
   latency "latency_histo" {
     error_margin = 0.05
-    unit         = "ms" // TODO: correct unit is microseconds which is not supported right now.
+    unit         = "ms"
     aggregator   = "PERCENTILE"
+    multiplier   = 0.001
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/lambda_cloudwatch.hcl
+++ b/modules/aws/lambda_cloudwatch.hcl
@@ -51,6 +51,7 @@ ingester aws_lambda_cloudwatch module {
     unit         = "ms"
     aggregator   = "PERCENTILE"
     error_margin = "0.05"
+    multiplier   = 1
 
     source cloudwatch "throughput" {
       query {

--- a/tests/aws_components_test.hcl
+++ b/tests/aws_components_test.hcl
@@ -82,15 +82,6 @@ extends aws_cloudfront_cloudwatch "cloudfront" {
     EOF
   }
 }
-extends aws_cloudfront_endpoint_cloudwatch "cloudfront_endpoint" {
-  source_uri = "../modules/aws/cloudfront_cloudwatch.hcl"
-  vars = {
-    using  = "default"
-    inputs = <<-EOF
-    [{"DistributionId": "blah"}]
-    EOF
-  }
-}
 extends aws_ec2_cloudwatch "ec2" {
   source_uri = "../modules/aws/ec2_cloudwatch.hcl"
   vars = {
@@ -100,16 +91,7 @@ extends aws_ec2_cloudwatch "ec2" {
     EOF
   }
 }
-extends aws_eks_containerinsights_service_cloudwatch "eks_containerinsights_service" {
-  source_uri = "../modules/aws/eks_containerinsights_cloudwatch.hcl"
-  vars = {
-    using  = "default"
-    inputs = <<-EOF
-    [{"ClusterName": "blah"}]
-    EOF
-  }
-}
-extends aws_eks_containerinsights_pod_cloudwatch "eks_containerinsights_pod" {
+extends aws_eks_containerinsights_pod_logical_cloudwatch "eks_containerinsights_pod" {
   source_uri = "../modules/aws/eks_containerinsights_cloudwatch.hcl"
   vars = {
     using  = "default"
@@ -154,15 +136,6 @@ extends aws_lambda_cloudwatch "lambda" {
     EOF
   }
 }
-extends aws_lambda_resource_cloudwatch "lambda_resource" {
-  source_uri = "../modules/aws/lambda_cloudwatch.hcl"
-  vars = {
-    using  = "default"
-    inputs = <<-EOF
-    [{"FunctionName": "blah"}]
-    EOF
-  }
-}
 extends aws_dynamodb_table_operation_cloudwatch "dynamodb_table_operation" {
   source_uri = "../modules/aws/dynamodb_cloudwatch.hcl"
   vars = {
@@ -186,16 +159,7 @@ extends aws_apigateway_cloudwatch "apigateway" {
   vars = {
     using  = "default"
     inputs = <<-EOF
-    [{"ApiName": "blah"}]
-    EOF
-  }
-}
-extends aws_apigateway_stage_cloudwatch "apigateway_stage" {
-  source_uri = "../modules/aws/apigateway_cloudwatch.hcl"
-  vars = {
-    using  = "default"
-    inputs = <<-EOF
-    [{"ApiName": "blah"}]
+    [{"ApiName": "blah", "Stage": "foo"}]
     EOF
   }
 }


### PR DESCRIPTION
Cloudwatch reports latency in microsecond, our histogram buckets assume the value in millisecond. So to convert microsecond in millisecond, we need to multiply the value by 0.001.

Fixing tests