### PR TITLE
Update EKS module (cluster)

### DIFF
--- a/modules/aws/eks_containerinsights_cloudwatch.hcl
+++ b/modules/aws/eks_containerinsights_cloudwatch.hcl
@@ -218,15 +218,15 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
     }
   }
 
-  gauge "cpu_limit" {
-    unit       = "count"
+  gauge "node_cpu_utilization" {
+    unit       = "percent"
     aggregator = "AVG"
 
-    source cloudwatch "cluster_cpu_limit" {
+    source cloudwatch "cluster_node_cpu_utilization" {
       query {
         aggregator  = "Average"
         namespace   = "ContainerInsights"
-        metric_name = "node_cpu_limit"
+        metric_name = "node_cpu_utilization"
         dimensions = {
           "ClusterName" = "$input{ClusterName}"
         }
@@ -234,15 +234,15 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
     }
   }
 
-  gauge "memory_limit" {
-    unit       = "bytes"
+  gauge "node_memory_utilization" {
+    unit       = "percent"
     aggregator = "AVG"
 
-    source cloudwatch "cluster_memory_limit" {
+    source cloudwatch "cluster_node_memory_utilization" {
       query {
         aggregator  = "Average"
         namespace   = "ContainerInsights"
-        metric_name = "node_memory_limit"
+        metric_name = "node_memory_utilization"
         dimensions = {
           "ClusterName" = "$input{ClusterName}"
         }


### PR DESCRIPTION
  - Remove "cpu_limit" and "memory_limit"
  - Add "node_memory_utilization" and "node_cpu_utilization"

```
> $ last9 iox plan --dir .

Metrics for: eks_containerinsights_cluster_ap-south-1
+-------------+-----------+-------------------------+----------------------+--------------+
| TOTAL NODES | DISK USED | NODE MEMORY UTILIZATION | NODE CPU UTILIZATION | FAILED NODES |
+-------------+-----------+-------------------------+----------------------+--------------+
|        3.00 |      1.31 |                   13.03 |                 2.68 |         0.00 |
|        3.00 |      1.31 |                   12.83 |                 2.80 |         0.00 |
|        3.00 |      1.31 |                   12.73 |                 2.63 |         0.00 |
|        3.00 |      1.31 |                   13.03 |                 2.57 |         0.00 |
|        3.00 |      1.31 |                   13.12 |                 3.97 |         0.00 |
|        3.00 |      1.31 |                   13.07 |                 2.86 |         0.00 |
|        3.00 |      1.31 |                   12.96 |                 3.35 |         0.00 |
|        3.00 |      1.31 |                   12.78 |                 2.85 |         0.00 |
|        3.00 |      1.31 |                   13.06 |                 2.87 |         0.00 |
|        3.00 |      1.31 |                   13.11 |                 3.85 |         0.00 |
+-------------+-----------+-------------------------+----------------------+--------------+

```