### PR TITLE
GCP: create modules for gcp cloud SQL

### DIFF
--- a/modules/gcp/cloud_sql.hcl
+++ b/modules/gcp/cloud_sql.hcl
@@ -1,0 +1,201 @@
+ingester gcp_cloud_sql_logical module {
+  lookback   = 600
+  frequency  = 60
+  timeout    = 30
+  resolution = 60
+  lag        = 0
+
+  physical_component {
+    type = "gcp_cloud_sql"
+    name = "$input{id}"
+  }
+
+  data_for_graph_node {
+    type = "gcp_cloud_sql"
+    name = "$input{id}"
+  }
+
+  using = {
+    "default" : "$input{using}"
+  }
+
+  inputs = "$input{inputs}"
+
+  gauge "connections" {
+    unit       = "count"
+    aggregator = "MAX"
+
+    source stackdriver "connections" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/network/connections"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+
+  gauge "write_ops_count" {
+    unit       = "iops"
+    aggregator = "AVG"
+
+    source stackdriver "write_ops_count" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/disk/write_ops_count"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+
+  gauge "read_ops_count" {
+    unit       = "iops"
+    aggregator = "AVG"
+
+    source stackdriver "read_ops_count" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/disk/read_ops_count"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+}
+
+ingester gcp_cloud_sql module {
+  lookback   = 600
+  frequency  = 60
+  timeout    = 30
+  resolution = 60
+  lag        = 0
+
+  physical_component {
+    type = "gcp_cloud_sql"
+    name = "$input{id}"
+  }
+
+  data_for_graph_node {
+    type = "gcp_cloud_sql"
+    name = "$input{id}"
+  }
+
+  using = {
+    "default" : "$input{using}"
+  }
+
+  inputs = "$input{inputs}"
+
+  gauge "cpu_utilization" {
+    unit       = "percent"
+    aggregator = "AVG"
+
+    source stackdriver "cpu" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/cpu/utilization"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+
+  gauge "bytes_received" {
+    unit       = "percent"
+    aggregator = "AVG"
+
+    source stackdriver "bytes_received" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/mysql/received_bytes_count"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+
+  gauge "bytes_sent" {
+    unit       = "percent"
+    aggregator = "AVG"
+
+    source stackdriver "bytes_sent" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/mysql/sent_bytes_count"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+
+  gauge "replica_lag" {
+    unit       = "percent"
+    aggregator = "AVG"
+
+    source stackdriver "replica_lag" {
+      query {
+        resource {}
+        aggregation {
+          per_series_aligner   = ""
+          cross_series_reducer = ""
+          group_by_fields      = []
+        }
+        metric {
+          type = "cloudsql.googleapis.com/database/replication/replica_lag"
+        }
+      }
+      join_on = {
+        "$output{database_id}" = "$input{id}"
+      }
+    }
+  }
+}

--- a/modules/gcp/cloudsql.hcl
+++ b/modules/gcp/cloudsql.hcl
@@ -6,13 +6,13 @@ ingester gcp_cloud_sql_logical module {
   lag        = 0
 
   physical_component {
-    type = "gcp_cloud_sql"
-    name = "$input{id}"
+    type = "cloudsql_cluster"
+    name = "$input{database_id}"
   }
 
   data_for_graph_node {
-    type = "gcp_cloud_sql"
-    name = "$input{id}"
+    type = "cloudsql_database"
+    name = "$input{database_id}-db"
   }
 
   using = {
@@ -38,16 +38,16 @@ ingester gcp_cloud_sql_logical module {
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
 
-  gauge "write_ops_count" {
+  gauge "write_iops" {
     unit       = "iops"
     aggregator = "AVG"
 
-    source stackdriver "write_ops_count" {
+    source stackdriver "write_iops" {
       query {
         resource {}
         aggregation {
@@ -60,16 +60,16 @@ ingester gcp_cloud_sql_logical module {
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
 
-  gauge "read_ops_count" {
+  gauge "read_iops" {
     unit       = "iops"
     aggregator = "AVG"
 
-    source stackdriver "read_ops_count" {
+    source stackdriver "read_iops" {
       query {
         resource {}
         aggregation {
@@ -82,7 +82,7 @@ ingester gcp_cloud_sql_logical module {
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
@@ -96,13 +96,13 @@ ingester gcp_cloud_sql module {
   lag        = 0
 
   physical_component {
-    type = "gcp_cloud_sql"
-    name = "$input{id}"
+    type = "cloudsql_cluster"
+    name = "$input{database_id}"
   }
 
   data_for_graph_node {
-    type = "gcp_cloud_sql"
-    name = "$input{id}"
+    type = "cloudsql_cluster"
+    name = "$input{database_id}"
   }
 
   using = {
@@ -111,91 +111,119 @@ ingester gcp_cloud_sql module {
 
   inputs = "$input{inputs}"
 
-  gauge "cpu_utilization" {
+  gauge "cpu" {
     unit       = "percent"
     aggregator = "AVG"
 
     source stackdriver "cpu" {
       query {
         resource {}
-        aggregation {
-          per_series_aligner   = ""
-          cross_series_reducer = ""
-          group_by_fields      = []
-        }
+        aggregation {}
         metric {
           type = "cloudsql.googleapis.com/database/cpu/utilization"
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
 
-  gauge "bytes_received" {
-    unit       = "percent"
+  gauge "network_in" {
+    unit       = "bps"
     aggregator = "AVG"
 
-    source stackdriver "bytes_received" {
+    source stackdriver "network_in" {
       query {
         resource {}
-        aggregation {
-          per_series_aligner   = ""
-          cross_series_reducer = ""
-          group_by_fields      = []
-        }
+        aggregation {}
         metric {
-          type = "cloudsql.googleapis.com/database/mysql/received_bytes_count"
+          type = "cloudsql.googleapis.com/database/network/received_bytes_count"
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
 
-  gauge "bytes_sent" {
-    unit       = "percent"
+  gauge "network_out" {
+    unit       = "bps"
     aggregator = "AVG"
 
-    source stackdriver "bytes_sent" {
+    source stackdriver "network_out" {
       query {
         resource {}
-        aggregation {
-          per_series_aligner   = ""
-          cross_series_reducer = ""
-          group_by_fields      = []
-        }
+        aggregation {}
         metric {
-          type = "cloudsql.googleapis.com/database/mysql/sent_bytes_count"
+          type = "cloudsql.googleapis.com/database/network/sent_bytes_count"
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
 
   gauge "replica_lag" {
-    unit       = "percent"
+    unit       = "s"
     aggregator = "AVG"
 
     source stackdriver "replica_lag" {
       query {
         resource {}
-        aggregation {
-          per_series_aligner   = ""
-          cross_series_reducer = ""
-          group_by_fields      = []
-        }
+        aggregation {}
         metric {
           type = "cloudsql.googleapis.com/database/replication/replica_lag"
         }
       }
       join_on = {
-        "$output{database_id}" = "$input{id}"
+        "$output{database_id}" = "$input{database_id}"
       }
     }
   }
+
+  # gauge "memory_utilization" {
+  #   unit       = "percent"
+  #   aggregator = "AVG"
+  #
+  #   source stackdriver "memory_utilization" {
+  #     query {
+  #       resource {}
+  #       aggregation {
+  #         per_series_aligner   = ""
+  #         cross_series_reducer = ""
+  #         group_by_fields      = []
+  #       }
+  #       metric {
+  #         type = "cloudsql.googleapis.com/database/memory/utilization"
+  #       }
+  #     }
+  #     join_on = {
+  #       "$output{database_id}" = "$input{database_id}"
+  #     }
+  #   }
+  # }
+  #
+  # gauge "disk_utilization" {
+  #   unit       = "percent"
+  #   aggregator = "AVG"
+  #
+  #   source stackdriver "disk_utilization" {
+  #     query {
+  #       resource {}
+  #       aggregation {
+  #         per_series_aligner   = ""
+  #         cross_series_reducer = ""
+  #         group_by_fields      = []
+  #       }
+  #       metric {
+  #         type = "cloudsql.googleapis.com/database/disk/utilization"
+  #       }
+  #     }
+  #     join_on = {
+  #       "$output{database_id}" = "$input{database_id}"
+  #     }
+  #   }
+  # }
 }

--- a/modules/gcp/cloudsql.hcl
+++ b/modules/gcp/cloudsql.hcl
@@ -104,7 +104,7 @@ ingester gcp_cloudsql_physical module {
     type = "service"
     name = "$input{service}"
   }
-  
+
   physical_component {
     type = "cloudsql_cluster"
     name = "$input{database_id}"

--- a/modules/gcp/cloudsql.hcl
+++ b/modules/gcp/cloudsql.hcl
@@ -1,9 +1,14 @@
-ingester gcp_cloud_sql_logical module {
+ingester gcp_cloudsql_logical module {
   lookback   = 600
   frequency  = 60
   timeout    = 30
   resolution = 60
   lag        = 0
+
+  label {
+    type = "service"
+    name = "$input{service}"
+  }
 
   physical_component {
     type = "cloudsql_cluster"
@@ -88,13 +93,18 @@ ingester gcp_cloud_sql_logical module {
   }
 }
 
-ingester gcp_cloud_sql module {
+ingester gcp_cloudsql_physical module {
   lookback   = 600
   frequency  = 60
   timeout    = 30
   resolution = 60
   lag        = 0
 
+  label {
+    type = "service"
+    name = "$input{service}"
+  }
+  
   physical_component {
     type = "cloudsql_cluster"
     name = "$input{database_id}"


### PR DESCRIPTION
IOX plan output:
```
> $ last9 iox plan --dir . --max-rows 100
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/mysql/sent_bytes_count"
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/mysql/received_bytes_count"
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/replication/replica_lag"
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/cpu/utilization"
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/disk/write_ops_count"
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/network/connections"
2021/08/11 16:02:01 source_stackdriver.go:229: metric.type="cloudsql.googleapis.com/database/disk/read_ops_count"

Metrics for: cloud_sql_logical
+------------+-----------------------------+----------------+-------------+-----------------+
| TIMESTAMP  |           NODE ID           | READ OPS COUNT | CONNECTIONS | WRITE OPS COUNT |
+------------+-----------------------------+----------------+-------------+-----------------+
| 1628677740 | 11225423250221576192.000000 |            860 |           6 |          124323 |
| 1628677680 | 11225423250221576192.000000 |            979 |           6 |          125423 |
| 1628677620 | 11225423250221576192.000000 |            846 |           6 |          124130 |
| 1628677560 | 11225423250221576192.000000 |            826 |           6 |          122133 |
| 1628677500 | 11225423250221576192.000000 |            902 |           6 |          126685 |
| 1628677440 | 11225423250221576192.000000 |            928 |           6 |          125435 |
| 1628677380 | 11225423250221576192.000000 |            952 |           6 |          127229 |
| 1628677320 | 11225423250221576192.000000 |            884 |           6 |          125645 |
| 1628677260 | 11225423250221576192.000000 |            913 |           6 |          123672 |
| 1628677800 | 11225423250221576192.000000 | NaN            |           6 |          126471 |
+------------+-----------------------------+----------------+-------------+-----------------+


Metrics for: cloud_sql
+------------+-----------------------------+------------+-------------+----------------+-----------------+
| TIMESTAMP  |           NODE ID           | BYTES SENT | REPLICA LAG | BYTES RECEIVED | CPU UTILIZATION |
+------------+-----------------------------+------------+-------------+----------------+-----------------+
| 1628677740 | 11225423250221576192.000000 |     175778 |        6985 |         827522 | NaN             |
| 1628677680 | 11225423250221576192.000000 |     180562 |        6987 |         851244 | NaN             |
| 1628677620 | 11225423250221576192.000000 |     178897 |        7008 |         928578 | NaN             |
| 1628677560 | 11225423250221576192.000000 |     186644 |        7029 |         930752 | NaN             |
| 1628677500 | 11225423250221576192.000000 |     218181 |        7050 |         961048 | NaN             |
| 1628677440 | 11225423250221576192.000000 |     181968 |        7071 |         948722 | NaN             |
| 1628677380 | 11225423250221576192.000000 |     177956 |        7097 |        1087399 | NaN             |
| 1628677320 | 11225423250221576192.000000 |     178375 |        7124 |        1244155 | NaN             |
| 1628677260 | 11225423250221576192.000000 |     191108 |        7142 |        1209438 | NaN             |
| 1628677800 | 11225423250221576192.000000 | NaN        | NaN         |       35692758 | NaN             |
| 1628677808 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.020588 |
| 1628677748 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019616 |
| 1628677688 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019616 |
| 1628677628 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019695 |
| 1628677568 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019870 |
| 1628677508 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.020025 |
| 1628677448 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019947 |
| 1628677388 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019965 |
| 1628677328 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019979 |
| 1628677268 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019688 |
| 1628677208 | 11225423250221576192.000000 | NaN        | NaN         | NaN            |        0.019637 |
+------------+-----------------------------+------------+-------------+----------------+-----------------+
```