### PR TITLE
[aws] compatibility with component creation

### DIFF
--- a/modules/aws/alb_cloudwatch.hcl
+++ b/modules/aws/alb_cloudwatch.hcl
@@ -703,7 +703,7 @@ ingester aws_alb_tg_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    index       = 3
+    index       = 2
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -1201,7 +1201,7 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    index       = 3
+    index       = 2
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"

--- a/modules/aws/alb_cloudwatch.hcl
+++ b/modules/aws/alb_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_alb_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -55,8 +57,10 @@ ingester aws_alb_cloudwatch module {
     }
   }
   gauge "new_connections" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "new_connections" {
       query {
         aggregator  = "Sum"
@@ -70,8 +74,10 @@ ingester aws_alb_cloudwatch module {
     }
   }
   gauge "rejected_connections" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "rejected_connections" {
       query {
         aggregator  = "Sum"
@@ -85,8 +91,10 @@ ingester aws_alb_cloudwatch module {
     }
   }
   gauge "processed_bytes" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "SUM"
     source cloudwatch "processed_bytes" {
       query {
         aggregator  = "Sum"
@@ -100,8 +108,10 @@ ingester aws_alb_cloudwatch module {
     }
   }
   gauge "lcu" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "lcu" {
       query {
         aggregator  = "Sum"
@@ -116,8 +126,10 @@ ingester aws_alb_cloudwatch module {
   }
 
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_500" {
       query {
@@ -132,8 +144,10 @@ ingester aws_alb_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_400" {
       query {
@@ -149,8 +163,10 @@ ingester aws_alb_cloudwatch module {
   }
 
   gauge lb_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_500" {
       query {
         aggregator  = "Sum"
@@ -164,8 +180,10 @@ ingester aws_alb_cloudwatch module {
     }
   }
   gauge lb_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_400" {
       query {
         aggregator  = "Sum"
@@ -180,7 +198,9 @@ ingester aws_alb_cloudwatch module {
   }
 
   latency "latency_histo" {
-    unit         = "s"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -299,8 +319,10 @@ ingester aws_alb_endpoint_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -314,7 +336,9 @@ ingester aws_alb_endpoint_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -390,8 +414,10 @@ ingester aws_alb_endpoint_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_500" {
       query {
@@ -406,8 +432,10 @@ ingester aws_alb_endpoint_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_400" {
       query {
@@ -423,8 +451,10 @@ ingester aws_alb_endpoint_cloudwatch module {
   }
 
   status_histo status_3xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_300" {
       query {
         aggregator  = "Sum"
@@ -449,8 +479,10 @@ ingester aws_alb_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_200" {
       query {
         aggregator  = "Sum"
@@ -512,8 +544,10 @@ ingester aws_alb_tg_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -528,7 +562,9 @@ ingester aws_alb_tg_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -610,8 +646,10 @@ ingester aws_alb_tg_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_500" {
       query {
@@ -627,8 +665,10 @@ ingester aws_alb_tg_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_400" {
       query {
@@ -645,8 +685,10 @@ ingester aws_alb_tg_cloudwatch module {
   }
 
   status_histo status_3xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_300" {
       query {
         aggregator  = "Sum"
@@ -661,8 +703,10 @@ ingester aws_alb_tg_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_200" {
       query {
         aggregator  = "Sum"
@@ -720,8 +764,10 @@ ingester aws_alb_internal_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -735,8 +781,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   gauge "new_connections" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "new_connections" {
       query {
         aggregator  = "Sum"
@@ -750,8 +798,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   gauge "rejected_connections" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "rejected_connections" {
       query {
         aggregator  = "Sum"
@@ -765,8 +815,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   gauge "processed_bytes" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "SUM"
     source cloudwatch "processed_bytes" {
       query {
         aggregator  = "Sum"
@@ -780,8 +832,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   gauge "lcu" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "lcu" {
       query {
         aggregator  = "Sum"
@@ -795,8 +849,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_500" {
       query {
@@ -811,8 +867,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_400" {
       query {
@@ -828,8 +886,10 @@ ingester aws_alb_internal_cloudwatch module {
   }
 
   gauge lb_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_500" {
       query {
         aggregator  = "Sum"
@@ -843,8 +903,10 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   gauge lb_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_400" {
       query {
         aggregator  = "Sum"
@@ -858,7 +920,9 @@ ingester aws_alb_internal_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -977,8 +1041,10 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -993,7 +1059,9 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
   }
   latency "latency_histo" {
     error_margin = 0.05
-    unit         = "ms"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     source cloudwatch "throughput" {
       query {
@@ -1068,8 +1136,10 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_500" {
       query {
@@ -1084,8 +1154,10 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source cloudwatch "status_400" {
       query {
@@ -1101,8 +1173,10 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
   }
 
   status_histo status_3xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_300" {
       query {
         aggregator  = "Sum"
@@ -1127,8 +1201,10 @@ ingester aws_alb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_200" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/apigateway_cloudwatch.hcl
+++ b/modules/aws/apigateway_cloudwatch.hcl
@@ -32,8 +32,10 @@ ingester aws_apigateway_cloudwatch module {
   inputs = "$input{inputs}"
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "througput" {
       query {
         aggregator  = "Sum"
@@ -49,7 +51,9 @@ ingester aws_apigateway_cloudwatch module {
   }
 
   latency "latency_histo" {
-    unit         = "ms"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     error_margin = 0.05
     multiplier   = 1
@@ -146,8 +150,10 @@ ingester aws_apigateway_cloudwatch module {
   }
 
   gauge "integration_latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "AVG"
     source cloudwatch "integration_latency" {
       query {
         aggregator  = "Average"
@@ -165,8 +171,10 @@ ingester aws_apigateway_cloudwatch module {
   // The Average statistic represents the cache hit rate, namely, the total count of the cache hits divided by
   // the total number of requests during the period
   gauge "cache_miss" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "cache_miss" {
       query {
         aggregator  = "Sum"
@@ -184,8 +192,10 @@ ingester aws_apigateway_cloudwatch module {
   // The Average statistic represents the 4XXError error rate, namely, the total count of the 4XXError errors divided by
   // the total number of requests during the period.
   status_histo "status_4xx" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_400" {
       query {
         aggregator  = "Sum"
@@ -202,8 +212,10 @@ ingester aws_apigateway_cloudwatch module {
   // The Average statistic represents the 5XXError error rate, namely, the total count of the 5XXError errors divided by
   // the total number of requests during the period.
   status_histo "status_5xx" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_500" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/apigateway_cloudwatch.hcl
+++ b/modules/aws/apigateway_cloudwatch.hcl
@@ -34,7 +34,7 @@ ingester aws_apigateway_cloudwatch module {
   gauge "throughput" {
     index       = 1
     input_unit  = "count"
-    output_unit = "count"
+    output_unit = "rpm"
     aggregator  = "SUM"
     source cloudwatch "througput" {
       query {

--- a/modules/aws/aurora_cloudwatch.hcl
+++ b/modules/aws/aurora_cloudwatch.hcl
@@ -32,8 +32,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   inputs = "$input{inputs}"
 
   gauge "connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "MAX"
     source cloudwatch "connections" {
       query {
         aggregator  = "Maximum"
@@ -48,8 +50,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "read_throughput" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "bps"
+    aggregator  = "AVG"
     source cloudwatch "read_throughput" {
       query {
         aggregator  = "Average"
@@ -65,8 +69,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
 
 
   gauge "read_latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "read_latency" {
       query {
         aggregator  = "Average"
@@ -81,8 +87,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "write_throughput" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "AVG"
     source cloudwatch "write_throughput" {
       query {
         aggregator  = "Average"
@@ -97,8 +105,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "write_latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "write_latency" {
       query {
         aggregator  = "Average"
@@ -113,8 +123,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "update_throughput" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "bps"
+    aggregator  = "AVG"
     source cloudwatch "update_throughput" {
       query {
         aggregator  = "Average"
@@ -129,8 +141,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "update_latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "update_latency" {
       query {
         aggregator  = "Average"
@@ -145,8 +159,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "delete_throughput" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "AVG"
     source cloudwatch "delete_throughput" {
       query {
         aggregator  = "Average"
@@ -161,8 +177,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "delete_latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 9
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "delete_latency" {
       query {
         aggregator  = "Average"
@@ -177,8 +195,10 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   }
 
   gauge "deadlocks" {
-    unit       = "tps"
-    aggregator = "MAX"
+    index       = 11
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "deadlocks" {
       query {
         aggregator  = "Maximum"
@@ -227,8 +247,10 @@ ingester aws_aurora_instance_physical_cloudwatch module {
   inputs = "$input{inputs}"
 
   gauge "network_in" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
     source cloudwatch "network_in" {
       query {
         aggregator  = "Average"
@@ -243,8 +265,10 @@ ingester aws_aurora_instance_physical_cloudwatch module {
   }
 
   gauge "network_out" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
     source cloudwatch "network_out" {
       query {
         aggregator  = "Average"
@@ -259,8 +283,10 @@ ingester aws_aurora_instance_physical_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "cpu" {
       query {
         aggregator  = "Average"
@@ -275,8 +301,10 @@ ingester aws_aurora_instance_physical_cloudwatch module {
   }
 
   gauge "free_space" {
-    unit       = "bytes"
-    aggregator = "MIN"
+    index       = 4
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "MIN"
     source cloudwatch "free_space" {
       query {
         aggregator  = "Minimum"
@@ -291,8 +319,10 @@ ingester aws_aurora_instance_physical_cloudwatch module {
   }
 
   gauge "replica_lag" {
-    unit       = "s"
-    aggregator = "MAX"
+    index       = 5
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "replica_lag" {
       query {
         aggregator  = "Maximum"
@@ -307,8 +337,10 @@ ingester aws_aurora_instance_physical_cloudwatch module {
   }
 
   gauge "queue_depth" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "queue_depth" {
       query {
         aggregator  = "Maximum"

--- a/modules/aws/aurora_cloudwatch.hcl
+++ b/modules/aws/aurora_cloudwatch.hcl
@@ -52,7 +52,7 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   gauge "read_throughput" {
     index       = 2
     input_unit  = "count"
-    output_unit = "bps"
+    output_unit = "rpm"
     aggregator  = "AVG"
     source cloudwatch "read_throughput" {
       query {
@@ -125,7 +125,7 @@ ingester aws_aurora_instance_logical_cloudwatch module {
   gauge "update_throughput" {
     index       = 6
     input_unit  = "count"
-    output_unit = "bps"
+    output_unit = "rpm"
     aggregator  = "AVG"
     source cloudwatch "update_throughput" {
       query {

--- a/modules/aws/cloudfront_cloudwatch.hcl
+++ b/modules/aws/cloudfront_cloudwatch.hcl
@@ -32,8 +32,10 @@ ingester aws_cloudfront_cloudwatch module {
   }
 
   gauge "status_5xx" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "SUM"
     source cloudwatch "5xx" {
       query {
         aggregator  = "Average"
@@ -47,8 +49,10 @@ ingester aws_cloudfront_cloudwatch module {
     }
   }
   gauge "status_4xx" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "SUM"
     source cloudwatch "4xx" {
       query {
         aggregator  = "Average"
@@ -62,8 +66,10 @@ ingester aws_cloudfront_cloudwatch module {
     }
   }
   gauge "bytes_out" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "bytes"
+    output_unit = "Bps"
+    aggregator  = "SUM"
     source cloudwatch "bytes_out" {
       query {
         aggregator  = "Sum"
@@ -77,8 +83,10 @@ ingester aws_cloudfront_cloudwatch module {
     }
   }
   gauge "bytes_in" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "bytes"
+    output_unit = "Bps"
+    aggregator  = "SUM"
     source cloudwatch "bytes_in" {
       query {
         aggregator  = "Sum"
@@ -92,8 +100,10 @@ ingester aws_cloudfront_cloudwatch module {
     }
   }
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/dax_cloudwatch.hcl
+++ b/modules/aws/dax_cloudwatch.hcl
@@ -45,8 +45,10 @@ ingester aws_dax_cloudwatch module {
   EOF
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -61,8 +63,10 @@ ingester aws_dax_cloudwatch module {
     }
   }
   gauge "errored" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "errors" {
       query {
         aggregator  = "Sum"
@@ -77,8 +81,10 @@ ingester aws_dax_cloudwatch module {
     }
   }
   gauge "throttled" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throttled" {
       query {
         aggregator  = "Sum"
@@ -93,8 +99,10 @@ ingester aws_dax_cloudwatch module {
     }
   }
   gauge "connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "connections" {
       query {
         aggregator  = "Maximum"
@@ -109,8 +117,10 @@ ingester aws_dax_cloudwatch module {
     }
   }
   gauge "query_miss" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "memory" {
       query {
         aggregator  = "Sum"
@@ -125,8 +135,10 @@ ingester aws_dax_cloudwatch module {
     }
   }
   gauge "cache_memory" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "memory" {
       query {
         aggregator  = "Average"
@@ -141,8 +153,10 @@ ingester aws_dax_cloudwatch module {
     }
   }
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "cpu" {
       query {
         aggregator  = "Average"

--- a/modules/aws/dynamodb_cloudwatch.hcl
+++ b/modules/aws/dynamodb_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_dynamodb_table_operation_cloudwatch module {
   EOF
 
   gauge "system_errors" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "system_errors" {
       query {
@@ -58,8 +60,10 @@ ingester aws_dynamodb_table_operation_cloudwatch module {
   }
 
   gauge "returned_items" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "returned_items" {
       query {
@@ -76,8 +80,10 @@ ingester aws_dynamodb_table_operation_cloudwatch module {
   }
 
   gauge "throttled" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "latency_update" {
       query {
@@ -94,8 +100,10 @@ ingester aws_dynamodb_table_operation_cloudwatch module {
   }
 
   gauge "latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "AVG"
 
     source cloudwatch "latency" {
       query {
@@ -154,8 +162,10 @@ ingester aws_dynamodb_table_cloudwatch module {
   EOF
 
   gauge "rcu" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "rcu" {
       query {
@@ -171,8 +181,10 @@ ingester aws_dynamodb_table_cloudwatch module {
   }
 
   gauge "wcu" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "wcu" {
       query {
@@ -188,8 +200,10 @@ ingester aws_dynamodb_table_cloudwatch module {
   }
 
   gauge "read_throttled" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "read_throttled" {
       query {
@@ -205,8 +219,10 @@ ingester aws_dynamodb_table_cloudwatch module {
   }
 
   gauge "write_throttled" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "write_throttled" {
       query {

--- a/modules/aws/ec2_cloudwatch.hcl
+++ b/modules/aws/ec2_cloudwatch.hcl
@@ -41,8 +41,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu" {
       query {
@@ -58,8 +60,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "disk_read_ops" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "tps"
+    aggregator  = "SUM"
 
     source cloudwatch "disk_read_ops" {
       query {
@@ -75,8 +79,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "disk_write_ops" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "tps"
+    aggregator  = "SUM"
 
     source cloudwatch "disk_write_ops" {
       query {
@@ -92,8 +98,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "network_in" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "bytes"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source cloudwatch "network_in" {
       query {
@@ -109,8 +117,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "network_out" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "bytes"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source cloudwatch "network_out" {
       query {
@@ -126,8 +136,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "status_check_failed" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "status_check_failed" {
       query {
@@ -143,8 +155,10 @@ ingester aws_ec2_cloudwatch module {
   }
 
   gauge "cpu_balance" {
-    unit       = "count"
-    aggregator = "MIN"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
 
     source cloudwatch "cpu_balance" {
       query {

--- a/modules/aws/eks_ci_k8s_deployment_cloudwatch.hcl
+++ b/modules/aws/eks_ci_k8s_deployment_cloudwatch.hcl
@@ -34,8 +34,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu" {
       query {
@@ -52,8 +54,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "memory" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory" {
       query {
@@ -70,8 +74,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "cpu_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu_overlimit" {
       query {
@@ -88,8 +94,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "memory_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory_overlimit" {
       query {
@@ -106,8 +114,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "bytes_in" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source cloudwatch "bytes_in" {
       query {
@@ -124,8 +134,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "bytes_out" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source cloudwatch "bytes_out" {
       query {
@@ -142,8 +154,10 @@ ingester aws_eks_containerinsights_deployment_without_service_cloudwatch module 
   }
 
   gauge "container_restarts" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "pod_number_of_container_restarts" {
       query {
@@ -201,8 +215,10 @@ ingester aws_eks_containerinsights_node_cloudwatch module {
   }
 
   gauge "cpu_used" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu_used" {
       query {
@@ -219,8 +235,10 @@ ingester aws_eks_containerinsights_node_cloudwatch module {
   }
 
   gauge "filesystem_used" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "filesystem_used" {
       query {
@@ -237,8 +255,10 @@ ingester aws_eks_containerinsights_node_cloudwatch module {
   }
 
   gauge "memory_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory_overlimit" {
       query {
@@ -255,8 +275,10 @@ ingester aws_eks_containerinsights_node_cloudwatch module {
   }
 
   gauge "running_pods" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "running_pods" {
       query {
@@ -273,8 +295,10 @@ ingester aws_eks_containerinsights_node_cloudwatch module {
   }
 
   gauge "running_containers" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "running_containers" {
       query {

--- a/modules/aws/eks_ci_k8s_service_cloudwatch.hcl
+++ b/modules/aws/eks_ci_k8s_service_cloudwatch.hcl
@@ -34,8 +34,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu" {
       query {
@@ -52,8 +54,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "memory" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory" {
       query {
@@ -70,8 +74,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "cpu_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu_overlimit" {
       query {
@@ -88,8 +94,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "memory_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory_overlimit" {
       query {
@@ -106,8 +114,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "bytes_in" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source cloudwatch "bytes_in" {
       query {
@@ -124,8 +134,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "bytes_out" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source cloudwatch "bytes_out" {
       query {
@@ -142,8 +154,10 @@ ingester aws_eks_containerinsights_service_cloudwatch module {
   }
 
   gauge "running_pods" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "running_pods" {
       query {
@@ -197,8 +211,10 @@ ingester eks_containerinsights_eks_cluster_cloudwatch module {
   }
 
   gauge "total_nodes" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "cluster_node_count" {
       query {
@@ -213,8 +229,10 @@ ingester eks_containerinsights_eks_cluster_cloudwatch module {
   }
 
   gauge "failed_nodes" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "cluster_failed_node_count" {
       query {
@@ -229,8 +247,10 @@ ingester eks_containerinsights_eks_cluster_cloudwatch module {
   }
 
   gauge "cpu_utilization" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cluster_node_cpu_utilization" {
       query {
@@ -245,8 +265,10 @@ ingester eks_containerinsights_eks_cluster_cloudwatch module {
   }
 
   gauge "memory_utilization" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cluster_node_memory_utilization" {
       query {
@@ -261,8 +283,10 @@ ingester eks_containerinsights_eks_cluster_cloudwatch module {
   }
 
   gauge "disk_used" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cluster_memory_limit" {
       query {

--- a/modules/aws/eks_containerinsights_cloudwatch.hcl
+++ b/modules/aws/eks_containerinsights_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu" {
       query {
@@ -58,8 +60,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "memory" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory" {
       query {
@@ -76,8 +80,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "cpu_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cpu_overlimit" {
       query {
@@ -94,8 +100,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "memory_overlimit" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "memory_overlimit" {
       query {
@@ -112,8 +120,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "bytes_in" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source cloudwatch "bytes_in" {
       query {
@@ -130,8 +140,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "bytes_out" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source cloudwatch "bytes_out" {
       query {
@@ -148,8 +160,10 @@ ingester aws_eks_containerinsights_pod_logical_cloudwatch module {
   }
 
   gauge "restarts" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source cloudwatch "pod_number_of_container_restarts" {
       query {
@@ -203,8 +217,10 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
   }
 
   gauge "total_nodes" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "cluster_node_count" {
       query {
@@ -219,8 +235,10 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
   }
 
   gauge "failed_nodes" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "cluster_failed_node_count" {
       query {
@@ -235,8 +253,10 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
   }
 
   gauge "cpu_utilization" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cluster_node_cpu_utilization" {
       query {
@@ -251,8 +271,10 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
   }
 
   gauge "memory_utilization" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 7
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cluster_node_memory_utilization" {
       query {
@@ -267,8 +289,10 @@ ingester aws_eks_containerinsights_cluster_cloudwatch module {
   }
 
   gauge "disk_used" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "cluster_memory_limit" {
       query {

--- a/modules/aws/elasticache_cloudwatch.hcl
+++ b/modules/aws/elasticache_cloudwatch.hcl
@@ -46,7 +46,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   EOF
 
   gauge "curr_connections" {
-    index = 1
+    index       = 1
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "AVG"
@@ -65,7 +65,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "new_connections" {
-    index = 3
+    index       = 3
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "AVG"
@@ -84,7 +84,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "curr_items" {
-    index = 2
+    index       = 2
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MAX"
@@ -103,7 +103,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "cache_hit_rate" {
-    index = 4
+    index       = 4
     input_unit  = "percent"
     output_unit = "percent"
     aggregator  = "MIN"
@@ -122,7 +122,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "cache_hits" {
-    index = 6
+    index       = 6
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MAX"
@@ -141,7 +141,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "cache_misses" {
-    index = 7
+    index       = 7
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MAX"
@@ -160,7 +160,7 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "evictions" {
-    index = 5
+    index       = 5
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "SUM"
@@ -179,7 +179,7 @@ ingester aws_elasticache_redis_cloudwatch module {
 
   latency "latency_histo" {
     error_margin = 0.05
-    index = 6
+    index        = 6
     input_unit   = "ms"
     output_unit  = "ms"
     aggregator   = "PERCENTILE"
@@ -288,7 +288,7 @@ ingester aws_elasticache_cluster_cloudwatch module {
   EOF
 
   gauge "replication_lag" {
-    index = 4
+    index       = 4
     input_unit  = "s"
     output_unit = "s"
     aggregator  = "MAX"
@@ -307,7 +307,7 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "bytes_out" {
-    index = 2
+    index       = 2
     input_unit  = "bytes"
     output_unit = "bps"
     aggregator  = "SUM"
@@ -326,7 +326,7 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "bytes_in" {
-    index = 3
+    index       = 3
     input_unit  = "bytes"
     output_unit = "bps"
     aggregator  = "SUM"
@@ -345,7 +345,7 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "cpu_used" {
-    index = 1
+    index       = 1
     input_unit  = "percent"
     output_unit = "percent"
     aggregator  = "AVG"
@@ -364,7 +364,7 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "memory_used" {
-    index = 5
+    index       = 5
     input_unit  = "percent"
     output_unit = "percent"
     aggregator  = "AVG"

--- a/modules/aws/elasticache_cloudwatch.hcl
+++ b/modules/aws/elasticache_cloudwatch.hcl
@@ -46,8 +46,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   EOF
 
   gauge "curr_connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source cloudwatch "CurrConnections" {
       query {
@@ -63,8 +65,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "new_connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source cloudwatch "NewConnections" {
       query {
@@ -80,8 +84,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "curr_items" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "CurrItems" {
       query {
@@ -97,8 +103,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "cache_hit_rate" {
-    unit       = "percent"
-    aggregator = "MIN"
+    index = 4
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "MIN"
 
     source cloudwatch "CacheHitRate" {
       query {
@@ -114,8 +122,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "cache_hits" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "CacheHits" {
       query {
@@ -131,8 +141,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "cache_misses" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "CacheMisses" {
       query {
@@ -148,8 +160,10 @@ ingester aws_elasticache_redis_cloudwatch module {
   }
 
   gauge "evictions" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "Evictions" {
       query {
         aggregator  = "Sum"
@@ -165,7 +179,9 @@ ingester aws_elasticache_redis_cloudwatch module {
 
   latency "latency_histo" {
     error_margin = 0.05
-    unit         = "ms"
+    index = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     multiplier   = 0.001
     source cloudwatch "throughput" {
@@ -272,8 +288,10 @@ ingester aws_elasticache_cluster_cloudwatch module {
   EOF
 
   gauge "replication_lag" {
-    unit       = "s"
-    aggregator = "MAX"
+    index = 4
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
 
     source cloudwatch "ReplicationLag" {
       query {
@@ -289,8 +307,10 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "bytes_out" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index = 2
+    input_unit  = "bytes"
+    output_unit = "bps"
+    aggregator  = "SUM"
 
     source cloudwatch "NetworkBytesOut" {
       query {
@@ -306,8 +326,10 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "bytes_in" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index = 3
+    input_unit  = "bytes"
+    output_unit = "bps"
+    aggregator  = "SUM"
 
     source cloudwatch "NetworkBytesIn" {
       query {
@@ -323,8 +345,10 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "cpu_used" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index = 1
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "EngineCPUUtilization" {
       query {
@@ -340,8 +364,10 @@ ingester aws_elasticache_cluster_cloudwatch module {
   }
 
   gauge "memory_used" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source cloudwatch "DatabaseMemoryUsagePercentage" {
       query {

--- a/modules/aws/elasticsearch_cloudwatch.hcl
+++ b/modules/aws/elasticsearch_cloudwatch.hcl
@@ -216,7 +216,7 @@ ingester aws_elasticsearch_cloudwatch module {
     index       = 12
     input_unit  = "percent"
     output_unit = "percent"
-    aggregator  = "MAX"
+    aggregator  = "AVG"
     source cloudwatch "jvm_memory_pressure" {
       query {
         aggregator  = "Maximum"

--- a/modules/aws/elasticsearch_cloudwatch.hcl
+++ b/modules/aws/elasticsearch_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_elasticsearch_cloudwatch module {
   EOF
 
   gauge "nodes" {
-    unit       = "count"
-    aggregator = "MIN"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
     source cloudwatch "nodes" {
       query {
         aggregator  = "Minimum"
@@ -57,8 +59,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "kibana_healthy_nodes" {
-    unit       = "count"
-    aggregator = "MIN"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
     source cloudwatch "kibana_healthy_nodes" {
       query {
         aggregator  = "Minimum"
@@ -74,8 +78,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "cluster_yellow" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "cluster_yellow" {
       query {
         aggregator  = "Maximum"
@@ -91,8 +97,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "cluster_red" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "cluster_red" {
       query {
         aggregator  = "Maximum"
@@ -108,8 +116,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -125,8 +135,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "status_4xx" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "status_4xx" {
       query {
         aggregator  = "Sum"
@@ -143,8 +155,10 @@ ingester aws_elasticsearch_cloudwatch module {
 
 
   gauge "status_5xx" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "5xx" {
       query {
         aggregator  = "Sum"
@@ -160,8 +174,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 8
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "cpu" {
       query {
         aggregator  = "Average"
@@ -178,8 +194,10 @@ ingester aws_elasticsearch_cloudwatch module {
 
 
   gauge "free_space" {
-    unit       = "bytes"
-    aggregator = "MIN"
+    index       = 11
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "MIN"
     source cloudwatch "free_space" {
       query {
         aggregator  = "Sum"
@@ -195,8 +213,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "jvm_memory_pressure" {
-    unit       = "percent"
-    aggregator = "MAX"
+    index       = 12
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "MAX"
     source cloudwatch "jvm_memory_pressure" {
       query {
         aggregator  = "Maximum"
@@ -212,8 +232,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "writes_blocked" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 13
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "writes_blocked" {
       query {
         aggregator  = "Maximum"
@@ -229,8 +251,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "snapshot_failure" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 14
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "snapshot_failure" {
       query {
         aggregator  = "Maximum"
@@ -246,8 +270,10 @@ ingester aws_elasticsearch_cloudwatch module {
   }
 
   gauge "master_reachable" {
-    unit       = "count"
-    aggregator = "MIN"
+    index       = 15
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
     source cloudwatch "master_reachable" {
       query {
         aggregator  = "Minimum"
@@ -314,8 +340,10 @@ ingester aws_elasticsearch_master_cloudwatch module {
 
 
   gauge "master_reachable" {
-    unit       = "count"
-    aggregator = "MIN"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
     source cloudwatch "master_reachable" {
       query {
         aggregator  = "Minimum"
@@ -331,8 +359,10 @@ ingester aws_elasticsearch_master_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "cpu" {
       query {
         aggregator  = "Average"
@@ -348,8 +378,10 @@ ingester aws_elasticsearch_master_cloudwatch module {
   }
 
   gauge "jvm_memory_pressure" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "jvm_memory_pressure" {
       query {
         aggregator  = "Maximum"

--- a/modules/aws/elb_cloudwatch.hcl
+++ b/modules/aws/elb_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_elb_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -55,8 +57,10 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge "surge_queue_length" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "MAX"
     source cloudwatch "surge_queue_length" {
       query {
         aggregator  = "Maximum"
@@ -70,8 +74,10 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge "connection_errors" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "connection_errors" {
       query {
         aggregator  = "Sum"
@@ -85,8 +91,10 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge "unhealthy_hosts" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "unhealthy_hosts" {
       query {
         aggregator  = "Maximum"
@@ -100,6 +108,10 @@ ingester aws_elb_cloudwatch module {
     }
   }
   status_histo status_5xx {
+    index = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_500" {
       query {
         aggregator  = "Sum"
@@ -113,6 +125,10 @@ ingester aws_elb_cloudwatch module {
     }
   }
   status_histo status_4xx {
+    index = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_400" {
       query {
         aggregator  = "Sum"
@@ -127,6 +143,10 @@ ingester aws_elb_cloudwatch module {
   }
 
   gauge lb_5xx {
+    index = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_500" {
       query {
         aggregator  = "Sum"
@@ -140,6 +160,10 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge lb_4xx {
+    index = 7
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_400" {
       query {
         aggregator  = "Sum"
@@ -153,7 +177,9 @@ ingester aws_elb_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "percentile"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -272,8 +298,10 @@ ingester aws_elb_internal_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -287,8 +315,10 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge "surge_queue_length" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "surge_queue_length" {
       query {
         aggregator  = "Maximum"
@@ -302,8 +332,10 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge "connection_errors" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "connection_errors" {
       query {
         aggregator  = "Sum"
@@ -317,8 +349,10 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge "unhealthy_hosts" {
-    unit       = "count"
-    aggregator = "MAX"
+    index = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "unhealthy_hosts" {
       query {
         aggregator  = "Maximum"
@@ -332,6 +366,10 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   status_histo status_5xx {
+    index = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_500" {
       query {
         aggregator  = "Sum"
@@ -345,6 +383,10 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   status_histo status_4xx {
+    index = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_400" {
       query {
         aggregator  = "Sum"
@@ -359,6 +401,10 @@ ingester aws_elb_internal_cloudwatch module {
   }
 
   gauge lb_5xx {
+    index = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_500" {
       query {
         aggregator  = "Sum"
@@ -372,6 +418,10 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge lb_4xx {
+    index = 7
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "lb_400" {
       query {
         aggregator  = "Sum"
@@ -385,7 +435,9 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "percentile"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -504,8 +556,10 @@ ingester aws_elb_endpoint_cloudwatch module {
   EOF
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -519,7 +573,9 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "percentile"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -595,8 +651,10 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_500" {
       query {
         aggregator  = "Sum"
@@ -610,8 +668,10 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_400" {
       query {
         aggregator  = "Sum"
@@ -625,8 +685,10 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_3xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_300" {
       query {
         aggregator  = "Sum"
@@ -640,8 +702,10 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_200" {
       query {
         aggregator  = "Sum"
@@ -698,8 +762,10 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
   EOF
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Sum"
@@ -713,7 +779,9 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    unit         = "s"
+    index = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "percentile"
     error_margin = 0.05
     source cloudwatch "throughput" {
@@ -789,8 +857,10 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_500" {
       query {
         aggregator  = "Sum"
@@ -804,8 +874,10 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_400" {
       query {
         aggregator  = "Sum"
@@ -819,8 +891,10 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_3xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_300" {
       query {
         aggregator  = "Sum"
@@ -834,8 +908,10 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    unit       = "count"
-    aggregator = "SUM"
+    index = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "status_200" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/elb_cloudwatch.hcl
+++ b/modules/aws/elb_cloudwatch.hcl
@@ -40,7 +40,7 @@ ingester aws_elb_cloudwatch module {
   }
 
   gauge "throughput" {
-    index = 1
+    index       = 1
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -57,7 +57,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge "surge_queue_length" {
-    index = 2
+    index       = 2
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "MAX"
@@ -74,7 +74,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge "connection_errors" {
-    index = 3
+    index       = 3
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "SUM"
@@ -91,7 +91,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge "unhealthy_hosts" {
-    index = 4
+    index       = 4
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MAX"
@@ -108,7 +108,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    index = 5
+    index       = 5
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -125,7 +125,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    index = 4
+    index       = 4
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -143,7 +143,7 @@ ingester aws_elb_cloudwatch module {
   }
 
   gauge lb_5xx {
-    index = 8
+    index       = 8
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -160,7 +160,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   gauge lb_4xx {
-    index = 7
+    index       = 7
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -177,7 +177,7 @@ ingester aws_elb_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    index = 6
+    index        = 6
     input_unit   = "ms"
     output_unit  = "ms"
     aggregator   = "percentile"
@@ -298,7 +298,7 @@ ingester aws_elb_internal_cloudwatch module {
   }
 
   gauge "throughput" {
-    index = 1
+    index       = 1
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -315,7 +315,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge "surge_queue_length" {
-    index = 2
+    index       = 2
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MAX"
@@ -332,7 +332,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge "connection_errors" {
-    index = 3
+    index       = 3
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "SUM"
@@ -349,7 +349,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge "unhealthy_hosts" {
-    index = 4
+    index       = 4
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MAX"
@@ -366,7 +366,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    index = 5
+    index       = 5
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -383,7 +383,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    index = 4
+    index       = 4
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -401,7 +401,7 @@ ingester aws_elb_internal_cloudwatch module {
   }
 
   gauge lb_5xx {
-    index = 8
+    index       = 8
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -418,7 +418,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   gauge lb_4xx {
-    index = 7
+    index       = 7
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -435,7 +435,7 @@ ingester aws_elb_internal_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    index = 6
+    index        = 6
     input_unit   = "ms"
     output_unit  = "ms"
     aggregator   = "percentile"
@@ -556,7 +556,7 @@ ingester aws_elb_endpoint_cloudwatch module {
   EOF
 
   gauge "throughput" {
-    index = 1
+    index       = 1
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -573,7 +573,7 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    index = 6
+    index        = 6
     input_unit   = "ms"
     output_unit  = "ms"
     aggregator   = "percentile"
@@ -651,7 +651,7 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    index = 5
+    index       = 5
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -668,7 +668,7 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    index = 4
+    index       = 4
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -685,7 +685,7 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_3xx {
-    index = 3
+    index       = 3
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -702,7 +702,7 @@ ingester aws_elb_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    index = 2
+    index       = 2
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -762,7 +762,7 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
   EOF
 
   gauge "throughput" {
-    index = 1
+    index       = 1
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -779,7 +779,7 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   latency "latency_histo" {
-    index = 6
+    index        = 6
     input_unit   = "ms"
     output_unit  = "ms"
     aggregator   = "percentile"
@@ -857,7 +857,7 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_5xx {
-    index = 5
+    index       = 5
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -874,7 +874,7 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_4xx {
-    index = 4
+    index       = 4
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -891,7 +891,7 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_3xx {
-    index = 3
+    index       = 3
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"
@@ -908,7 +908,7 @@ ingester aws_elb_internal_endpoint_cloudwatch module {
     }
   }
   status_histo status_2xx {
-    index = 2
+    index       = 2
     input_unit  = "count"
     output_unit = "rpm"
     aggregator  = "SUM"

--- a/modules/aws/lambda_cloudwatch.hcl
+++ b/modules/aws/lambda_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_lambda_cloudwatch module {
   EOF
 
   gauge "invocations" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "invocations" {
       query {
         aggregator  = "Sum"
@@ -56,7 +58,9 @@ ingester aws_lambda_cloudwatch module {
   }
 
   latency "latency_histo" {
-    unit         = "ms"
+    index        = 6
+    input_unit   = "ms"
+    output_unit  = "ms"
     aggregator   = "PERCENTILE"
     error_margin = "0.05"
     multiplier   = 1
@@ -135,8 +139,10 @@ ingester aws_lambda_cloudwatch module {
   }
 
   gauge "concurrent_executions" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "concurrent_executions" {
       query {
         aggregator  = "Maximum"
@@ -151,8 +157,10 @@ ingester aws_lambda_cloudwatch module {
   }
 
   gauge "concurrency_spillover" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "concurrency_spillover" {
       query {
         aggregator  = "Sum"
@@ -167,8 +175,10 @@ ingester aws_lambda_cloudwatch module {
   }
 
   gauge "throttles" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "throttles" {
       query {
         aggregator  = "Sum"
@@ -183,8 +193,10 @@ ingester aws_lambda_cloudwatch module {
   }
 
   gauge "errors" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "errors" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/msk_cloudwatch.hcl
+++ b/modules/aws/msk_cloudwatch.hcl
@@ -133,7 +133,7 @@ ingester aws_msk_topic_per_broker_cloudwatch module {
     }
   }
   gauge "produce_msg_conversions" {
-    index       = 1
+    index       = 2
     input_unit  = "tps"
     output_unit = "tps"
     aggregator  = "AVG"

--- a/modules/aws/msk_cloudwatch.hcl
+++ b/modules/aws/msk_cloudwatch.hcl
@@ -53,8 +53,10 @@ ingester aws_msk_topic_per_broker_cloudwatch module {
   }
 
   gauge "bytes_in" {
-    unit       = "bps"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
     source cloudwatch "data_in" {
       query {
         aggregator  = "Sum"
@@ -71,8 +73,10 @@ ingester aws_msk_topic_per_broker_cloudwatch module {
     }
   }
   gauge "bytes_out" {
-    unit       = "bps"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
     source cloudwatch "data_out" {
       query {
         aggregator  = "Sum"
@@ -89,8 +93,10 @@ ingester aws_msk_topic_per_broker_cloudwatch module {
     }
   }
   gauge "messages_in" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source cloudwatch "messages_in" {
       query {
         aggregator  = "Average"
@@ -107,8 +113,10 @@ ingester aws_msk_topic_per_broker_cloudwatch module {
     }
   }
   gauge "fetch_msg_conversions" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source cloudwatch "fetch_msg_conversions" {
       query {
         aggregator  = "Average"
@@ -125,8 +133,10 @@ ingester aws_msk_topic_per_broker_cloudwatch module {
     }
   }
   gauge "produce_msg_conversions" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source cloudwatch "produce_msg_conversions" {
       query {
         aggregator  = "Average"
@@ -191,8 +201,10 @@ ingester aws_msk_topic_per_consumer_grp_cloudwatch module {
   }
 
   gauge "offset_lag" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "offset_lag" {
       query {
@@ -268,8 +280,10 @@ ingester aws_msk_partition_cloudwatch module {
   }
 
   gauge "offset_lag" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "offset_lag" {
       query {
@@ -288,8 +302,10 @@ ingester aws_msk_partition_cloudwatch module {
   }
 
   gauge "time_lag" {
-    unit       = "seconds"
-    aggregator = "MAX"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "time_lag" {
       query {
@@ -356,8 +372,10 @@ ingester aws_msk_cluster_cloudwatch module {
   }
 
   gauge "active_controller_count" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "active_controller_count" {
       query {
@@ -375,8 +393,10 @@ ingester aws_msk_cluster_cloudwatch module {
   }
 
   gauge "offline_partition_count" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source cloudwatch "offline_partition_count" {
       query {
@@ -447,8 +467,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "mem_free" {
-    unit       = "bytes"
-    aggregator = "MIN"
+    index       = 12
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "MIN"
     source cloudwatch "mem_free" {
       query {
         aggregator  = "Minimum"
@@ -465,8 +487,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "messages_in" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source cloudwatch "messages_in" {
       query {
         aggregator  = "Average"
@@ -483,8 +507,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "partition_count" {
-    unit       = "count"
-    aggregator = "MIN"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
     source cloudwatch "partition_count" {
       query {
         aggregator  = "Minimum"
@@ -501,8 +527,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "produce_time_ms_mean" {
-    unit       = "milliseconds"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "AVG"
     source cloudwatch "produce_time_ms_mean" {
       query {
         aggregator  = "Average"
@@ -519,8 +547,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "request_bytes_mean" {
-    unit       = "bytes"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
     source cloudwatch "request_bytes_mean" {
       query {
         aggregator  = "Sum"
@@ -537,8 +567,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "request_time" {
-    unit       = "milliseconds"
-    aggregator = "AVG"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "AVG"
     source cloudwatch "request_time" {
       query {
         aggregator  = "Average"
@@ -555,8 +587,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "produce_msg_conversions" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source cloudwatch "produce_msg_conversions" {
       query {
         aggregator  = "Average"
@@ -573,8 +607,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "fetch_msg_conversions" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source cloudwatch "fetch_msg_conversions" {
       query {
         aggregator  = "Average"
@@ -591,8 +627,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "fetch_time_ms_mean" {
-    unit       = "milliseconds"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "AVG"
     source cloudwatch "fetch_time_ms_mean" {
       query {
         aggregator  = "Average"
@@ -609,8 +647,10 @@ ingester aws_msk_broker_cloudwatch module {
   }
 
   gauge "root_disk_used" {
-    unit       = "percentage"
-    aggregator = "MAX"
+    index       = 11
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "MAX"
     source cloudwatch "root_disk_used" {
       query {
         aggregator  = "Maximum"

--- a/modules/aws/nlb_cloudwatch.hcl
+++ b/modules/aws/nlb_cloudwatch.hcl
@@ -40,8 +40,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "MAX"
     source cloudwatch "throughput" {
       query {
         aggregator  = "Maximum"
@@ -56,8 +58,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "new_connections" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "new_connections" {
       query {
         aggregator  = "Sum"
@@ -72,8 +76,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "concurrent_connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 9
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "MAX"
     source cloudwatch "concurrent_connections" {
       query {
         aggregator  = "Maximum"
@@ -89,8 +95,10 @@ ingester aws_nlb_cloudwatch module {
 
 
   gauge "processed_bytes" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "ProcessedBytes" {
       query {
         aggregator  = "Sum"
@@ -105,8 +113,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "consumed_lcus" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "consumed_lcus" {
       query {
         aggregator  = "Sum"
@@ -121,8 +131,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "tcp_client_reset_count" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "tcp_client_reset_count" {
       query {
         aggregator  = "Sum"
@@ -137,8 +149,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "tcp_elb_reset_count" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "tcp_elb_reset_count" {
       query {
         aggregator  = "Sum"
@@ -153,8 +167,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "tcp_target_reset_count" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "tcp_target_reset_count" {
       query {
         aggregator  = "Sum"
@@ -169,8 +185,10 @@ ingester aws_nlb_cloudwatch module {
   }
 
   gauge "target_tls_error" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudwatch "target_tls_error" {
       query {
         aggregator  = "Sum"

--- a/modules/aws/rds_cloudwatch.hcl
+++ b/modules/aws/rds_cloudwatch.hcl
@@ -41,8 +41,10 @@ ingester aws_rds_logical_cloudwatch module {
   EOF
 
   gauge "connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "connections" {
       query {
         aggregator  = "Maximum"
@@ -57,8 +59,10 @@ ingester aws_rds_logical_cloudwatch module {
   }
 
   gauge "write_iops" {
-    unit       = "iops"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "iops"
+    output_unit = "iops"
+    aggregator  = "AVG"
     source cloudwatch "write_iops" {
       query {
         aggregator  = "Average"
@@ -73,8 +77,10 @@ ingester aws_rds_logical_cloudwatch module {
   }
 
   gauge "read_iops" {
-    unit       = "iops"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "iops"
+    output_unit = "iops"
+    aggregator  = "AVG"
     source cloudwatch "read_iops" {
       query {
         aggregator  = "Average"
@@ -89,8 +95,10 @@ ingester aws_rds_logical_cloudwatch module {
   }
 
   gauge "read_latency" {
-    unit       = "s"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "AVG"
     source cloudwatch "read_latency" {
       query {
         aggregator  = "Average"
@@ -105,8 +113,10 @@ ingester aws_rds_logical_cloudwatch module {
   }
 
   gauge "write_latency" {
-    unit       = "s"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "AVG"
     source cloudwatch "wrtie_latency" {
       query {
         aggregator  = "Average"
@@ -163,8 +173,10 @@ ingester aws_rds_physical_cloudwatch module {
   EOF
 
   gauge "network_in" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
     source cloudwatch "network_in" {
       query {
         aggregator  = "Average"
@@ -179,8 +191,10 @@ ingester aws_rds_physical_cloudwatch module {
   }
 
   gauge "network_out" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
     source cloudwatch "network_out" {
       query {
         aggregator  = "Average"
@@ -195,8 +209,10 @@ ingester aws_rds_physical_cloudwatch module {
   }
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
     source cloudwatch "cpu" {
       query {
         aggregator  = "Average"
@@ -211,8 +227,10 @@ ingester aws_rds_physical_cloudwatch module {
   }
 
   gauge "free_space" {
-    unit       = "bytes"
-    aggregator = "MIN"
+    index       = 4
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "MIN"
     source cloudwatch "free_space" {
       query {
         aggregator  = "Minimum"
@@ -227,8 +245,10 @@ ingester aws_rds_physical_cloudwatch module {
   }
 
   gauge "replica_lag" {
-    unit       = "s"
-    aggregator = "MAX"
+    index       = 5
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "replica_lag" {
       query {
         aggregator  = "Maximum"
@@ -243,8 +263,10 @@ ingester aws_rds_physical_cloudwatch module {
   }
 
   gauge "queue_depth" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source cloudwatch "queue_depth" {
       query {
         aggregator  = "Maximum"

--- a/modules/aws/sqs_cloudwatch.hcl
+++ b/modules/aws/sqs_cloudwatch.hcl
@@ -35,8 +35,10 @@ ingester aws_sqs_cloudwatch module {
   EOF
 
   gauge "sent" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "sent" {
       query {
         aggregator  = "Sum"
@@ -51,8 +53,10 @@ ingester aws_sqs_cloudwatch module {
   }
 
   gauge "received" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "received" {
       query {
         aggregator  = "Sum"
@@ -67,8 +71,10 @@ ingester aws_sqs_cloudwatch module {
   }
 
   gauge "visible" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "visible" {
       query {
         aggregator  = "Sum"
@@ -83,8 +89,10 @@ ingester aws_sqs_cloudwatch module {
   }
 
   gauge "empty_receives" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "empty_receives" {
       query {
         aggregator  = "Sum"
@@ -99,8 +107,10 @@ ingester aws_sqs_cloudwatch module {
   }
 
   gauge "deleted" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "deleted" {
       query {
         aggregator  = "Sum"
@@ -115,8 +125,10 @@ ingester aws_sqs_cloudwatch module {
   }
 
   gauge "delayed" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source cloudwatch "delayed" {
       query {
         aggregator  = "Sum"
@@ -131,8 +143,10 @@ ingester aws_sqs_cloudwatch module {
   }
 
   gauge "oldest" {
-    unit       = "s"
-    aggregator = "MAX"
+    index       = 7
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
     source cloudwatch "oldest" {
       query {
         aggregator  = "Maximum"

--- a/modules/cloudflare/cdn.hcl
+++ b/modules/cloudflare/cdn.hcl
@@ -39,7 +39,10 @@ ingester cloudflare_cdn module {
   inputs = "$input{inputs}"
 
   gauge "throughput" {
-    unit = "rpm"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "throughput" {
       query = <<-EOH
 {
@@ -65,7 +68,10 @@ EOH
   }
 
   gauge "status_2xx" {
-    unit = "rpm"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "2xx" {
       query = <<-EOH
 {
@@ -95,7 +101,10 @@ EOH
   }
 
   gauge "status_3xx" {
-    unit = "rpm"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "3xx" {
       query = <<-EOH
 {
@@ -125,7 +134,10 @@ EOH
   }
 
   gauge "status_4xx" {
-    unit = "rpm"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "4xx" {
       query = <<-EOH
 {
@@ -155,7 +167,10 @@ EOH
   }
 
   gauge "status_5xx" {
-    unit = "rpm"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "5xx" {
       query = <<-EOH
 {
@@ -226,7 +241,10 @@ ingester cloudflare_waf module {
   inputs = "$input{inputs}"
 
   gauge "throughput" {
-    unit = "rpm"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "throughput" {
       query = <<-EOH
 {
@@ -252,7 +270,10 @@ EOH
   }
 
   gauge "connection_close" {
-    unit = "rpm"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "connection_close" {
       query = <<-EOH
   {
@@ -279,7 +300,10 @@ EOH
   }
 
   gauge "bypass" {
-    unit = "rpm"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "bypass" {
       query = <<-EOH
   {
@@ -306,7 +330,10 @@ EOH
   }
 
   gauge "jschallenge" {
-    unit = "rpm"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "jschallenge" {
       query = <<-EOH
   {
@@ -333,7 +360,10 @@ EOH
   }
 
   gauge "log" {
-    unit = "rpm"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "log" {
       query = <<-EOH
   {
@@ -360,7 +390,10 @@ EOH
   }
 
   gauge "block" {
-    unit = "rpm"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "block" {
       query = <<-EOH
   {
@@ -387,7 +420,10 @@ EOH
   }
 
   gauge "status_2xx" {
-    unit = "rpm"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "2xx" {
       query = <<-EOH
   {
@@ -417,7 +453,10 @@ EOH
   }
 
   gauge "status_4xx" {
-    unit = "rpm"
+    index       = 8
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "4xx" {
       query = <<-EOH
   {
@@ -447,7 +486,10 @@ EOH
   }
 
   gauge "status_5xx" {
-    unit = "rpm"
+    index       = 9
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
     source cloudflare "5xx" {
       query = <<-EOH
   {

--- a/modules/gcp/cloudsql.hcl
+++ b/modules/gcp/cloudsql.hcl
@@ -27,8 +27,10 @@ ingester gcp_cloudsql_logical module {
   inputs = "$input{inputs}"
 
   gauge "connections" {
-    unit       = "count"
-    aggregator = "MAX"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source stackdriver "connections" {
       query {
@@ -49,8 +51,10 @@ ingester gcp_cloudsql_logical module {
   }
 
   gauge "write_iops" {
-    unit       = "iops"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "iops"
+    output_unit = "iops"
+    aggregator  = "AVG"
 
     source stackdriver "write_iops" {
       query {
@@ -71,8 +75,10 @@ ingester gcp_cloudsql_logical module {
   }
 
   gauge "read_iops" {
-    unit       = "iops"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "iops"
+    output_unit = "iops"
+    aggregator  = "AVG"
 
     source stackdriver "read_iops" {
       query {
@@ -122,8 +128,10 @@ ingester gcp_cloudsql_physical module {
   inputs = "$input{inputs}"
 
   gauge "cpu" {
-    unit       = "percent"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "AVG"
 
     source stackdriver "cpu" {
       query {
@@ -140,8 +148,10 @@ ingester gcp_cloudsql_physical module {
   }
 
   gauge "network_in" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source stackdriver "network_in" {
       query {
@@ -158,8 +168,10 @@ ingester gcp_cloudsql_physical module {
   }
 
   gauge "network_out" {
-    unit       = "bps"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "bps"
+    output_unit = "bps"
+    aggregator  = "AVG"
 
     source stackdriver "network_out" {
       query {
@@ -176,8 +188,10 @@ ingester gcp_cloudsql_physical module {
   }
 
   gauge "replica_lag" {
-    unit       = "s"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "AVG"
 
     source stackdriver "replica_lag" {
       query {
@@ -194,7 +208,9 @@ ingester gcp_cloudsql_physical module {
   }
 
   # gauge "memory_utilization" {
-  #   unit       = "percent"
+  #   index = 1
+  #   input_unit       = "percent"
+  #   output_unit       = "percent"
   #   aggregator = "AVG"
   #
   #   source stackdriver "memory_utilization" {
@@ -216,7 +232,9 @@ ingester gcp_cloudsql_physical module {
   # }
   #
   # gauge "disk_utilization" {
-  #   unit       = "percent"
+  #   index = 1
+  #   input_unit       = "percent"
+  #   output_unit       = "percent"
   #   aggregator = "AVG"
   #
   #   source stackdriver "disk_utilization" {

--- a/modules/managed/aerospike_datadog.hcl
+++ b/modules/managed/aerospike_datadog.hcl
@@ -43,8 +43,10 @@ ingester managed_aerospike_namespace_ops_read_datadog module {
   }
 
   gauge "client_success" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source datadog "client_success" {
       query = "sum:aerospike.namespace.client_read_success{*} by {namespace,host}.rollup(sum, 60)"
 
@@ -55,8 +57,10 @@ ingester managed_aerospike_namespace_ops_read_datadog module {
   }
 
   gauge "client_error" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source datadog "client_error" {
       query = "sum:aerospike.namespace.client_read_error{*} by {namespace,host}.rollup(sum, 60)"
 
@@ -67,8 +71,10 @@ ingester managed_aerospike_namespace_ops_read_datadog module {
   }
 
   gauge "client_timeout" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source datadog "client_timeout" {
       query = "sum:aerospike.namespace.client_read_timeout{*} by {namespace,host}.rollup(sum, 60)"
 
@@ -124,8 +130,10 @@ ingester managed_aerospike_namespace_sets_datadog module {
   }
 
   gauge "memory" {
-    unit       = "bytes"
-    aggregator = "AVG"
+    index       = 4
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "AVG"
     source datadog "memory" {
       query = "avg:aerospike.set.memory_data_bytes{*} by {set,namespace,host}.rollup(avg, 60)"
 
@@ -136,8 +144,10 @@ ingester managed_aerospike_namespace_sets_datadog module {
   }
 
   gauge "objects" {
-    unit       = "count"
-    aggregator = "AVG"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
     source datadog "objects" {
       query = "avg:aerospike.set.objects{*} by {set,namespace,host}.rollup(avg, 60)"
 
@@ -148,8 +158,10 @@ ingester managed_aerospike_namespace_sets_datadog module {
   }
 
   gauge "stop_write" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source datadog "client_timeout" {
       query = "sum:aerospike.set.stop_writes_count{*} by {set,namespace,host}.rollup(sum, 60)"
 
@@ -201,8 +213,10 @@ ingester managed_aerospike_namespace_datadog module {
   }
 
   gauge "query" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 1
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source datadog "query" {
       query = "avg:aerospike.namespace.tps.query{*} by {namespace,host}.rollup(avg, 60)"
 
@@ -213,8 +227,10 @@ ingester managed_aerospike_namespace_datadog module {
   }
 
   gauge "read" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source datadog "read" {
       query = "avg:aerospike.namespace.tps.read{*} by {namespace,host}.rollup(avg, 60)"
 
@@ -225,8 +241,10 @@ ingester managed_aerospike_namespace_datadog module {
   }
 
   gauge "write" {
-    unit       = "tps"
-    aggregator = "AVG"
+    index       = 3
+    input_unit  = "tps"
+    output_unit = "tps"
+    aggregator  = "AVG"
     source datadog "write" {
       query = "avg:aerospike.namespace.tps.write{*} by {namespace,host}.rollup(avg, 60)"
 

--- a/modules/managed/kong_datadog.hcl
+++ b/modules/managed/kong_datadog.hcl
@@ -32,8 +32,10 @@ ingester managed_kong_endpoint_datadog module {
   }
 
   gauge "throughput" {
-    unit       = "count"
-    aggregator = "SUM"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
     source datadog "throughput" {
       query = "sum:kong.request.count{*} by {cluster,env,kong_upstream,route}.rollup(sum, 60)"
 
@@ -46,8 +48,10 @@ ingester managed_kong_endpoint_datadog module {
   }
 
   gauge "latency" {
-    unit       = "ms"
-    aggregator = "AVG"
+    index       = 2
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "AVG"
     source datadog "avg_latency" {
       query = "avg:kong.latency.avg{*} by {cluster,env,kong_upstream,route}.rollup(sum, 60)"
 

--- a/modules/prometheus/istio_multi_cluster.hcl
+++ b/modules/prometheus/istio_multi_cluster.hcl
@@ -43,7 +43,10 @@ ingester prometheus_istio_workload module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       //query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, pod_name) (increase(istio_requests_total{ reporter='destination', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m]))"
@@ -56,7 +59,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "response_code"
@@ -69,7 +75,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "response_code"
@@ -82,7 +91,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "response_code"
@@ -95,7 +107,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "response_code"
@@ -108,7 +123,10 @@ ingester prometheus_istio_workload module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       histo_column = "le"
@@ -123,7 +141,10 @@ ingester prometheus_istio_workload module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_request_bytes_sum{  reporter='destination', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -135,7 +156,10 @@ ingester prometheus_istio_workload module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace,  destination_version, pod_name) (increase(istio_response_bytes_sum{  reporter='destination', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -182,7 +206,10 @@ ingester prometheus_istio_cluster module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "sum by (cluster) (increase(istio_requests_total{ reporter='destination'}[1m]))"
@@ -194,7 +221,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "response_code"
@@ -207,7 +237,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "response_code"
@@ -220,7 +253,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "response_code"
@@ -233,7 +269,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "response_code"
@@ -246,7 +285,10 @@ ingester prometheus_istio_cluster module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "sum by (cluster) (increase(istio_request_bytes_sum{ reporter='destination'}[1m]))"
@@ -258,7 +300,10 @@ ingester prometheus_istio_cluster module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "sum by (cluster) (increase(istio_response_bytes_sum{ reporter='destination'}[1m]))"
@@ -270,7 +315,10 @@ ingester prometheus_istio_cluster module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT
@@ -324,7 +372,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_requests_total{ reporter='destination', destination_service_name!='PassthroughCluster', source_canonical_service!='unknown', destination_canonical_service=~'.+'}[1m]))"
@@ -336,7 +387,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "response_code"
@@ -349,7 +403,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "response_code"
@@ -362,7 +419,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "response_code"
@@ -375,7 +435,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "response_code"
@@ -388,7 +451,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_request_bytes_sum{ reporter='destination', destination_service_name!='PassthroughCluster', source_canonical_service!='unknown', destination_canonical_service=~'.+'}[1m]))"
@@ -400,7 +466,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_response_bytes_sum{ reporter='destination', destination_service_name!='PassthroughCluster', source_canonical_service!='unknown', destination_canonical_service=~'.+' }[1m]))"
@@ -412,7 +481,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT

--- a/modules/prometheus/istio_tcp_services.hcl
+++ b/modules/prometheus/istio_tcp_services.hcl
@@ -38,7 +38,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "open_connections" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "open_connections" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_tcp_connections_opened_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -50,7 +53,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "closed_connections" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "closed_connections" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_tcp_connections_closed_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -62,7 +68,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_tcp_received_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -74,7 +83,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace,  destination_version, pod_name) (increase(istio_tcp_sent_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -122,7 +134,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "open_connections" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "open_connections" {
       query = "label_set(sum by (cluster) (increase(istio_tcp_connections_opened_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -134,7 +149,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "closed_connections" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "closed_connections" {
       query = "label_set(sum by (cluster) (increase(istio_tcp_connections_closed_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -146,7 +164,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "label_set(sum by (cluster) (increase(istio_tcp_received_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -158,7 +179,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace,  destination_version, pod_name) (increase(istio_tcp_sent_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -209,7 +233,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "open_connections" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "open_connections" {
       query = "label_set(sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_tcp_connections_opened_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -221,7 +248,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "closed_connections" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "closed_connections" {
       query = "label_set(sum by (cluster, destination_canonical_service, destination_workload_namespace, pod_name) (increase(istio_tcp_connections_closed_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -233,7 +263,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "label_set(sum by (cluster, destination_canonical_service, destination_workload_namespace, pod_name) (increase(istio_tcp_received_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"
@@ -245,7 +278,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "label_set(sum by (cluster, destination_canonical_service, destination_workload_namespace, pod_name) (increase(istio_tcp_sent_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m])), 'cluster', '$input{cluster}')"

--- a/modules/prometheus/istio_tcp_services_without_label_set.hcl
+++ b/modules/prometheus/istio_tcp_services_without_label_set.hcl
@@ -43,7 +43,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "open_connections" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "open_connections" {
       query = "sum by (cluster, destination_canonical_service, destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_tcp_connections_opened_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -55,7 +58,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "closed_connections" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "closed_connections" {
       query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_tcp_connections_closed_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -67,7 +73,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_tcp_received_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -79,7 +88,10 @@ ingester prometheus_istio_tcp_workload module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace,  destination_version, pod_name) (increase(istio_tcp_sent_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -127,7 +139,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "open_connections" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "open_connections" {
       query = "sum by (cluster) (increase(istio_tcp_connections_opened_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m]))"
@@ -139,7 +154,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "closed_connections" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "closed_connections" {
       query = "sum by (cluster) (increase(istio_tcp_connections_closed_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m]))"
@@ -151,7 +169,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "sum by (cluster) (increase(istio_tcp_received_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m]))"
@@ -163,7 +184,10 @@ ingester prometheus_istio_tcp_cluster module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace,  destination_version, pod_name) (increase(istio_tcp_sent_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m]))"
@@ -214,7 +238,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "open_connections" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "open_connections" {
       query = "sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_tcp_connections_opened_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -226,7 +253,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "closed_connections" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "closed_connections" {
       query = "sum by (cluster, destination_canonical_service, destination_workload_namespace, pod_name) (increase(istio_tcp_connections_closed_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -238,7 +268,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "sum by (cluster, destination_canonical_service, destination_workload_namespace, pod_name) (increase(istio_tcp_received_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"
@@ -250,7 +283,10 @@ ingester prometheus_istio_tcp_k8s_pod module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "sum by (cluster, destination_canonical_service, destination_workload_namespace, pod_name) (increase(istio_tcp_sent_bytes_total{reporter='source', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', destination_canonical_service=~'.+'}[1m]))"

--- a/modules/prometheus/istio_with_single_cluster.hcl
+++ b/modules/prometheus/istio_with_single_cluster.hcl
@@ -38,7 +38,10 @@ ingester prometheus_istio_workload module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       //query = "sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_requests_total{reporter='destination', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster'}[1m]))"
@@ -51,7 +54,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "response_code"
@@ -64,7 +70,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "response_code"
@@ -77,7 +86,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "response_code"
@@ -90,7 +102,10 @@ ingester prometheus_istio_workload module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "response_code"
@@ -103,7 +118,10 @@ ingester prometheus_istio_workload module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace, destination_version, pod_name) (increase(istio_request_bytes_sum{reporter='destination', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', pod_name=~'.+'}[1m])), 'cluster', '$input{cluster}')"
@@ -115,7 +133,10 @@ ingester prometheus_istio_workload module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "label_set(sum by (cluster, destination_canonical_service,  destination_workload, destination_workload_namespace,  destination_version, pod_name) (increase(istio_response_bytes_sum{reporter='destination', source_canonical_service!='unknown', destination_service_name!='PassthroughCluster', pod_name=~'.+'}[1m])), 'cluster', '$input{cluster}')"
@@ -127,7 +148,10 @@ ingester prometheus_istio_workload module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT
@@ -178,7 +202,10 @@ ingester prometheus_istio_cluster module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "label_set(sum by (cluster) (increase(istio_requests_total{reporter='destination'}[1m])), 'cluster', '$input{cluster}')"
@@ -190,7 +217,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "response_code"
@@ -203,7 +233,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "response_code"
@@ -216,7 +249,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "response_code"
@@ -229,7 +265,10 @@ ingester prometheus_istio_cluster module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "response_code"
@@ -242,7 +281,10 @@ ingester prometheus_istio_cluster module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "label_set(sum by (cluster) (increase(istio_request_bytes_sum{reporter='destination'}[1m])), 'cluster', '$input{cluster}')"
@@ -254,7 +296,10 @@ ingester prometheus_istio_cluster module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "label_set(sum by (cluster) (increase(istio_response_bytes_sum{reporter='destination'}[1m])), 'cluster', '$input{cluster}')"
@@ -266,7 +311,10 @@ ingester prometheus_istio_cluster module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT
@@ -321,7 +369,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "label_set(sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_requests_total{reporter='destination', destination_service_name!='PassthroughCluster', source_canonical_service!='unknown', pod_name=~'.+'}[1m])), 'cluster', '$input{cluster}')"
@@ -333,7 +384,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "response_code"
@@ -346,7 +400,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "response_code"
@@ -359,7 +416,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "response_code"
@@ -372,7 +432,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "response_code"
@@ -385,7 +448,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   gauge "bytes_in" {
-    unit = "bytes"
+    index       = 1
+    input_unit  = "Bpw"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_in" {
       query = "label_set(sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_request_bytes_sum{reporter='destination', destination_service_name!='PassthroughCluster', source_canonical_service!='unknown', pod_name=~'.+'}[1m])), 'cluster', '$input{cluster}')"
@@ -397,7 +463,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   gauge "bytes_out" {
-    unit = "bytes"
+    index       = 2
+    input_unit  = "Bps"
+    output_unit = "Bps"
+    aggregator  = "SUM"
 
     source prometheus "bytes_out" {
       query = "label_set(sum by (cluster, pod_name, destination_canonical_service, destination_workload_namespace) (increase(istio_response_bytes_sum{reporter='destination', destination_service_name!='PassthroughCluster', source_canonical_service!='unknown', pod_name=~'.+'}[1m])), 'cluster', '$input{cluster}')"
@@ -409,7 +478,10 @@ ingester prometheus_istio_k8s_pod module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT

--- a/modules/prometheus/k8s_via_kube_state.hcl
+++ b/modules/prometheus/k8s_via_kube_state.hcl
@@ -32,7 +32,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "available_nodes" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
 
     source prometheus "available_nodes" {
       query = <<EOF
@@ -46,7 +49,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "disk_pressure_nodes" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "disk_pressure_nodes" {
       query = <<EOF
@@ -60,7 +66,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "pid_pressure_nodes" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pid_pressure_nodes" {
       query = <<EOF
@@ -74,7 +83,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "memory_pressure_nodes" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "memory_pressure_nodes" {
       query = <<EOF
@@ -88,7 +100,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "requested_memory" {
-    unit = "bytes"
+    index       = 5
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "MAX"
 
     source prometheus "requested_memory" {
       query = "label_set(sum(kube_pod_container_resource_requests{resource='memory', unit='byte'})/sum by (cluster)(kube_node_status_allocatable{resource='memory', unit='byte'}), 'cluster', '$input{cluster}')"
@@ -99,7 +114,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "requested_cpu" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "requested_cpu" {
       query = "label_set(sum(kube_pod_container_resource_requests{resource='cpu', unit='core'})/sum by (cluster)(kube_node_status_allocatable{resource='cpu', unit='core'}), 'cluster', '$input{cluster}')"
@@ -110,7 +128,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "saturated_nodes" {
-    unit = "count"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "saturated_nodes" {
       query = "label_set(sum by (cluster) (kube_node_spec_unschedulable{}), 'cluster', '$input{cluster}')"
@@ -156,7 +177,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "unscheduled_pods" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "unscheduled_pods" {
       query = "label_set(sum by (cluster, namespace) (increase(kube_pod_status_unschedulable{}[1m])), 'cluster', '$input{cluster}')"
@@ -167,7 +191,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "desired_pods" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "desired_pods" {
       query = "label_set(sum by (cluster, namespace) (increase(kube_pod_status_phase{}[1m])), 'cluster', '$input{cluster}')"
@@ -178,7 +205,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "running_pods" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "running_pods" {
       query = "label_set(sum by (cluster, namespace) (kube_pod_status_phase{phase=~'Running'}), 'cluster', '$input{cluster}')"
@@ -189,7 +219,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "pending_pods" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pending_pods" {
       query = "label_set(sum by (cluster, namespace) (kube_pod_status_phase{phase=~'Pending'}), 'cluster', '$input{cluster}')"
@@ -200,7 +233,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "failed_and_unknown_pods" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed_and_unknown_pods" {
       query = "label_set(sum by (cluster, namespace) (kube_pod_status_phase{phase=~'Failed|Unknown'}), 'cluster', '$input{cluster}')"
@@ -211,7 +247,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "container_restarts" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "container_restarts" {
       query = "label_set(sum by (cluster, namespace) (kube_pod_container_status_restarts_total{}), 'cluster', '$input{cluster}')"
@@ -262,7 +301,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "disk_pressure" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "disk_pressure" {
       query = <<EOF
@@ -276,7 +318,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "pid_pressure" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pid_pressure" {
       query = <<EOF
@@ -290,7 +335,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "memory_pressure" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "memory_pressure" {
       query = <<EOF
@@ -304,7 +352,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "saturated" {
-    unit = "count"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "saturated" {
       query = "label_set(sum by (cluster, node) (kube_node_spec_unschedulable{}), 'cluster', '$input{cluster}')"
@@ -361,7 +412,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "container_restarted" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "container_restarted" {
       query = <<EOT
@@ -374,7 +428,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_failed" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_failed" {
       query = <<EOT
@@ -387,7 +444,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_running" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_running" {
       query = <<EOT
@@ -400,7 +460,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_desired" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_desired" {
       query = <<EOT
@@ -413,7 +476,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_cold" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_cold" {
       query = <<EOT
@@ -476,7 +542,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "container_restarted" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "container_restarted" {
       query = <<EOT
@@ -489,7 +558,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_failed" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_failed" {
       query = <<EOT
@@ -502,7 +574,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_running" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_running" {
       query = <<EOT
@@ -515,7 +590,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_desired" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_desired" {
       query = <<EOT
@@ -528,7 +606,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_cold" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_cold" {
       query = <<EOT
@@ -595,7 +676,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "total_container_restarts" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "total_container_restarts" {
       query = <<EOT
@@ -608,7 +692,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_in_terminated" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "container_in_terminated" {
       query = <<EOT
@@ -621,7 +708,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_in_waiting" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "container_in_waiting" {
       query = <<EOT
@@ -634,7 +724,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_cpu_limit" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "container_cpu_limit" {
       query = <<EOT
@@ -647,7 +740,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_memory_limit" {
-    unit = "bytes"
+    index       = 5
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "AVG"
 
     source prometheus "container_memory_limit" {
       query = <<EOT
@@ -706,7 +802,10 @@ ingester prometheus_kube_deployment module {
   }
 
   gauge "unavailable_replicas" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "unavailable_replicas" {
       query = "label_set(sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_unavailable{}), 'cluster', '$input{cluster}')"
@@ -717,7 +816,10 @@ ingester prometheus_kube_deployment module {
   }
 
   gauge "desired_replicas" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "desired_replicas" {
       query = "label_set(sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas{}), 'cluster', '$input{cluster}')"
@@ -729,7 +831,10 @@ ingester prometheus_kube_deployment module {
 
 
   gauge "cold_replicas" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source prometheus "cold_replicas" {
       query = "label_set(sum by (cluster, namespace, deployment) (kube_deployment_status_replicas{}) - sum by (cluster, namespace, deployment)(kube_deployment_status_replicas_available{}), 'cluster', '$input{cluster}')"
       join_on = {

--- a/modules/prometheus/k8s_via_kube_state_without_label_set.hcl
+++ b/modules/prometheus/k8s_via_kube_state_without_label_set.hcl
@@ -32,7 +32,11 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "available_nodes" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
+
 
     source prometheus "available_nodes" {
       query = <<EOF
@@ -46,7 +50,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "disk_pressure_nodes" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "disk_pressure_nodes" {
       query = <<EOF
@@ -60,7 +67,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "pid_pressure_nodes" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pid_pressure_nodes" {
       query = <<EOF
@@ -74,7 +84,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "memory_pressure_nodes" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "memory_pressure_nodes" {
       query = <<EOF
@@ -88,7 +101,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "requested_memory" {
-    unit = "bytes"
+    index       = 5
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "MAX"
 
     source prometheus "requested_memory" {
       query = "sum(kube_pod_container_resource_requests{resource='memory', unit='byte'})/sum by (cluster)(kube_node_status_allocatable{resource='memory', unit='byte'})"
@@ -99,7 +115,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "requested_cpu" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "requested_cpu" {
       query = "sum(kube_pod_container_resource_requests{resource='cpu', unit='core'})/sum by (cluster)(kube_node_status_allocatable{resource='cpu', unit='core'})"
@@ -110,7 +129,10 @@ ingester prometheus_kube_cluster module {
   }
 
   gauge "saturated_nodes" {
-    unit = "count"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "saturated_nodes" {
       query = "sum by (cluster) (kube_node_spec_unschedulable{})"
@@ -156,7 +178,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "unscheduled_pods" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "unscheduled_pods" {
       query = "sum by (cluster, namespace) (increase(kube_pod_status_unschedulable{}[1m]))"
@@ -167,7 +192,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "desired_pods" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "desired_pods" {
       query = "sum by (cluster, namespace) (increase(kube_pod_status_phase{}[1m]))"
@@ -178,7 +206,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "running_pods" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "running_pods" {
       query = "sum by (cluster, namespace) (kube_pod_status_phase{phase=~'Running'})"
@@ -189,7 +220,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "pending_pods" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pending_pods" {
       query = "sum by (cluster, namespace) (kube_pod_status_phase{phase=~'Pending'})"
@@ -200,7 +234,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "failed_and_unknown_pods" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed_and_unknown_pods" {
       query = "sum by (cluster, namespace) (kube_pod_status_phase{phase=~'Failed|Unknown'})"
@@ -211,7 +248,10 @@ ingester prometheus_kube_cluster_with_namespace module {
   }
 
   gauge "container_restarts" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "container_restarts" {
       query = "sum by (cluster, namespace) (kube_pod_container_status_restarts_total{})"
@@ -262,7 +302,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "disk_pressure" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "disk_pressure" {
       query = <<EOF
@@ -276,7 +319,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "pid_pressure" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pid_pressure" {
       query = <<EOF
@@ -290,7 +336,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "memory_pressure" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "memory_pressure" {
       query = <<EOF
@@ -304,7 +353,10 @@ ingester prometheus_kube_node module {
   }
 
   gauge "saturated" {
-    unit = "count"
+    index       = 7
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "saturated" {
       query = "sum by (cluster, node) (kube_node_spec_unschedulable{})"
@@ -360,7 +412,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "container_restarted" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "container_restarted" {
       query = <<EOT
@@ -373,7 +428,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_failed" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_failed" {
       query = <<EOT
@@ -386,7 +444,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_running" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_running" {
       query = <<EOT
@@ -399,7 +460,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_desired" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_desired" {
       query = <<EOT
@@ -412,7 +476,10 @@ ingester prometheus_kube_pod_grp module {
   }
 
   gauge "containers_cold" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_cold" {
       query = <<EOT
@@ -475,7 +542,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "container_restarted" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "container_restarted" {
       query = <<EOT
@@ -488,7 +558,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_failed" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_failed" {
       query = <<EOT
@@ -501,7 +574,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_running" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_failed" {
       query = <<EOT
@@ -514,7 +590,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_desired" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_desired" {
       query = <<EOT
@@ -527,7 +606,10 @@ ingester prometheus_kube_pod module {
   }
 
   gauge "containers_cold" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "containers_cold" {
       query = <<EOT
@@ -594,7 +676,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "total_container_restarts" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "total_container_restarts" {
       query = <<EOT
@@ -607,7 +692,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_in_terminated" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "container_in_terminated" {
       query = <<EOT
@@ -620,7 +708,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_in_waiting" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "SUM"
 
     source prometheus "container_in_waiting" {
       query = <<EOT
@@ -633,7 +724,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_cpu_limit" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "container_cpu_limit" {
       query = <<EOT
@@ -646,7 +740,10 @@ ingester prometheus_kube_container module {
   }
 
   gauge "container_memory_limit" {
-    unit = "bytes"
+    index       = 5
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "AVG"
 
     source prometheus "container_memory_limit" {
       query = <<EOT
@@ -705,7 +802,10 @@ ingester prometheus_kube_deployment module {
   }
 
   gauge "unavailable_replicas" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "unavailable_replicas" {
       query = "sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_unavailable{})"
@@ -716,7 +816,10 @@ ingester prometheus_kube_deployment module {
   }
 
   gauge "desired_replicas" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "desired_replicas" {
       query = "sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas{})"
@@ -728,7 +831,10 @@ ingester prometheus_kube_deployment module {
 
 
   gauge "cold_replicas" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
     source prometheus "cold_replicas" {
       query = "sum by (cluster, namespace, deployment) (kube_deployment_status_replicas{}) - sum by (cluster, namespace, deployment)(kube_deployment_status_replicas_available{})"
       join_on = {

--- a/modules/prometheus/linkerd.hcl
+++ b/modules/prometheus/linkerd.hcl
@@ -37,7 +37,10 @@ ingester prometheus_linkerd_workload module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "label_set(label_replace((sum by (cluster, workload_ns, deployment, dst, pod) (increase(route_request_total{direction='inbound', dst=~'.*svc.cluster.local.*'})[1m])), 'service', '$1', 'dst', '([a-zA-Z0-9-]*){1}.([a-zA-Z-.]*):.*'), 'cluster', '$input{cluster}')"
@@ -49,7 +52,10 @@ ingester prometheus_linkerd_workload module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "status_code"
@@ -62,7 +68,10 @@ ingester prometheus_linkerd_workload module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "status_code"
@@ -75,7 +84,10 @@ ingester prometheus_linkerd_workload module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "status_code"
@@ -88,7 +100,10 @@ ingester prometheus_linkerd_workload module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "status_code"
@@ -101,7 +116,10 @@ ingester prometheus_linkerd_workload module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT
@@ -155,7 +173,10 @@ ingester prometheus_linkerd_k8s_pod module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "label_set(label_replace((sum by (cluster, workload_ns, deployment, dst, pod) (increase(route_request_total{direction='inbound', dst=~'.*svc.cluster.local.*'})[1m])), 'service', '$1', 'dst', '([a-zA-Z0-9-]*){1}.([a-zA-Z-.]*):.*'), 'cluster', '$input{cluster}')"
@@ -167,7 +188,10 @@ ingester prometheus_linkerd_k8s_pod module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "status_code"
@@ -180,7 +204,10 @@ ingester prometheus_linkerd_k8s_pod module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "status_code"
@@ -193,7 +220,10 @@ ingester prometheus_linkerd_k8s_pod module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "status_code"
@@ -206,7 +236,10 @@ ingester prometheus_linkerd_k8s_pod module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "status_code"
@@ -219,7 +252,10 @@ ingester prometheus_linkerd_k8s_pod module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT

--- a/modules/prometheus/linkerd_path_based.hcl
+++ b/modules/prometheus/linkerd_path_based.hcl
@@ -32,7 +32,10 @@ ingester prometheus_linkerd_path module {
   }
 
   gauge "throughput" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "throughput" {
       query = "label_set(label_replace((sum by (cluster, workload_ns, dst, rt_route) (increase(route_request_total{direction='outbound', dst=~'.*svc.cluster.local.*', rt_route!=''})[1m])), 'service', '$1', 'dst', '([a-zA-Z0-9-]*){1}.([a-zA-Z-.]*):.*'), 'cluster', '$input{cluster}')"
@@ -44,7 +47,10 @@ ingester prometheus_linkerd_path module {
   }
 
   status_histo "status_2xx" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_2xx" {
       histo_column = "status_code"
@@ -57,7 +63,10 @@ ingester prometheus_linkerd_path module {
   }
 
   status_histo "status_3xx" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_3xx" {
       histo_column = "status_code"
@@ -70,7 +79,10 @@ ingester prometheus_linkerd_path module {
   }
 
   status_histo "status_4xx" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_4xx" {
       histo_column = "status_code"
@@ -83,7 +95,10 @@ ingester prometheus_linkerd_path module {
   }
 
   status_histo "status_5xx" {
-    unit = "count"
+    index       = 5
+    input_unit  = "count"
+    output_unit = "rpm"
+    aggregator  = "SUM"
 
     source prometheus "status_5xx" {
       histo_column = "status_code"
@@ -96,7 +111,10 @@ ingester prometheus_linkerd_path module {
   }
 
   latency_histo "latency_histo" {
-    unit = "ms"
+    index       = 6
+    input_unit  = "ms"
+    output_unit = "ms"
+    aggregator  = "PERCENTILE"
 
     source prometheus "latency" {
       query = <<EOT

--- a/modules/prometheus/remote_write.hcl
+++ b/modules/prometheus/remote_write.hcl
@@ -33,7 +33,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "pending" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pending" {
       query = "label_set(sum by (pod) (prometheus_remote_storage_samples_pending{}), 'pod', '$input{pod}')"
@@ -44,7 +47,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "retried" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "retried" {
       query = "label_set(max by (pod) (rate(prometheus_remote_storage_samples_retried_total{}[1m])), 'pod', '$input{pod}')"
@@ -55,7 +61,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "failed" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed" {
       query = "label_set(max by (pod) (rate(prometheus_remote_storage_samples_failed_total{}[1m])), 'pod', '$input{pod}')"
@@ -66,7 +75,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "dropped" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed" {
       query = "label_set(max by (pod) (rate(prometheus_remote_storage_samples_dropped_total{}[1m])), 'pod', '$input{pod}')"
@@ -77,7 +89,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "processed_percent" {
-    unit = "percent"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "MIN"
 
     source prometheus "processed_percent" {
       query = "label_set((1 - (sum by (pod) (prometheus_remote_storage_samples_pending{}) / max by (pod) (rate(prometheus_remote_storage_samples_in_total{}[1m])*60))) * 100, 'pod', '$input{pod}')"
@@ -88,7 +103,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "bytes_sent" {
-    unit = "bytes"
+    index       = 8
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "AVG"
 
     source prometheus "bytes_sent" {
       query = "label_set(sum by (pod) (rate(prometheus_remote_storage_samples_bytes_total{}[1m])*60 or rate(prometheus_remote_storage_bytes_total{}[1m])*60) + sum by (pod) (rate(prometheus_remote_storage_metadata_bytes_total{}[1m])*60), 'pod', '$input{pod}')"
@@ -99,7 +117,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "wal_lag" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "wal_lag" {
       query = "label_set((max by (pod) (max_over_time(prometheus_tsdb_wal_segment_current{}[1m]))) - (max by (pod) (max_over_time(prometheus_wal_watcher_current_segment{}[1m]))), 'pod', '$input{pod}')"
@@ -111,7 +132,10 @@ ingester prometheus_remote_write module {
 
 
   gauge "timestamp_lag" {
-    unit = "seconds"
+    index       = 7
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
 
     source prometheus "timestamp_lag" {
       query = "label_set(max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{}[1m]) - ignoring(remote_name, url) group_right max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{}[1m]), 'pod', '$input{pod}')"
@@ -122,7 +146,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "available_shards" {
-    unit = "count"
+    index       = 9
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "available_shards" {
       query = "label_set(max by (pod) (max_over_time(prometheus_remote_storage_shards_max{}[1m])) - max by (pod) (max_over_time(prometheus_remote_storage_shards_desired{}[1m])), 'pod', '$input{pod}')"

--- a/modules/prometheus/remote_write_pre_v2_30.hcl
+++ b/modules/prometheus/remote_write_pre_v2_30.hcl
@@ -33,7 +33,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "pending" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pending" {
       query = "label_set(sum by (pod) (prometheus_remote_storage_pending_samples{}), 'pod', '$input{pod}')"
@@ -44,7 +47,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "retried" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "retried" {
       query = "label_set(max by (pod) (rate(prometheus_remote_storage_retried_samples_total{}[1m])), 'pod', '$input{pod}')"
@@ -55,7 +61,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "failed" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed" {
       query = "label_set(max by (pod) (rate(prometheus_remote_storage_failed_samples_total{}[1m])), 'pod', '$input{pod}')"
@@ -66,7 +75,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "dropped" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed" {
       query = "label_set(max by (pod) (rate(prometheus_remote_storage_dropped_samples_total{}[1m])), 'pod', '$input{pod}')"
@@ -77,7 +89,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "processed_percent" {
-    unit = "percent"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "MIN"
 
     source prometheus "processed_percent" {
       query = "label_set((1 - (sum by (pod) (prometheus_remote_storage_pending_samples{}) / max by (pod) (rate(prometheus_remote_storage_samples_in_total{}[1m])*60))) * 100, 'pod', '$input{pod}')"
@@ -88,7 +103,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "bytes_sent" {
-    unit = "bytes"
+    index       = 8
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "AVG"
 
     source prometheus "bytes_sent" {
       query = "label_set(sum by (pod) (rate(prometheus_remote_storage_sent_bytes_total{}[1m])*60), 'pod', '$input{pod}')"
@@ -99,7 +117,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "wal_lag" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "wal_lag" {
       query = "label_set((max by (pod) (max_over_time(prometheus_tsdb_wal_segment_current{}[1m]))) - (max by (pod) (max_over_time(prometheus_wal_watcher_current_segment{}[1m]))), 'pod', '$input{pod}')"
@@ -111,7 +132,10 @@ ingester prometheus_remote_write module {
 
 
   gauge "timestamp_lag" {
-    unit = "seconds"
+    index       = 7
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
 
     source prometheus "timestamp_lag" {
       query = "label_set(max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{}[1m]) - ignoring(remote_name, url) group_right max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{}[1m]), 'pod', '$input{pod}')"
@@ -122,7 +146,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "available_shards" {
-    unit = "count"
+    index       = 9
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "available_shards" {
       query = "label_set(max by (pod) (max_over_time(prometheus_remote_storage_shards_max{}[1m])) - max by (pod) (max_over_time(prometheus_remote_storage_shards_desired{}[1m])), 'pod', '$input{pod}')"

--- a/modules/prometheus/remote_write_without_label_set.hcl
+++ b/modules/prometheus/remote_write_without_label_set.hcl
@@ -33,7 +33,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "pending" {
-    unit = "count"
+    index       = 1
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "pending" {
       query = "sum by (pod) (prometheus_remote_storage_samples_pending{})"
@@ -44,7 +47,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "retried" {
-    unit = "count"
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "retried" {
       query = "max by (pod) (rate(prometheus_remote_storage_samples_retried_total{}[1m]))"
@@ -55,7 +61,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "failed" {
-    unit = "count"
+    index       = 3
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed" {
       query = "max by (pod) (rate(prometheus_remote_storage_samples_failed_total{}[1m]))"
@@ -66,7 +75,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "dropped" {
-    unit = "count"
+    index       = 4
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "failed" {
       query = "max by (pod) (rate(prometheus_remote_storage_samples_dropped_total{}[1m]))"
@@ -77,7 +89,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "processed_percent" {
-    unit = "percent"
+    index       = 5
+    input_unit  = "percent"
+    output_unit = "percent"
+    aggregator  = "MIN"
 
     source prometheus "processed_percent" {
       query = "(1 - (sum by (pod) (prometheus_remote_storage_samples_pending{}) / max by (pod) (rate(prometheus_remote_storage_samples_in_total{}[1m])*60))) * 100"
@@ -88,7 +103,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "bytes_sent" {
-    unit = "bytes"
+    index       = 8
+    input_unit  = "bytes"
+    output_unit = "bytes"
+    aggregator  = "AVG"
 
     source prometheus "bytes_sent" {
       query = "sum by (pod) (rate(prometheus_remote_storage_samples_bytes_total{}[1m])*60 or rate(prometheus_remote_storage_bytes_total{}[1m])*60) + sum by (pod) (rate(prometheus_remote_storage_metadata_bytes_total{}[1m])*60)"
@@ -99,7 +117,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "wal_lag" {
-    unit = "count"
+    index       = 6
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MAX"
 
     source prometheus "wal_lag" {
       query = "(max by (pod) (max_over_time(prometheus_tsdb_wal_segment_current{}[1m]))) - (max by (pod) (max_over_time(prometheus_wal_watcher_current_segment{}[1m])))"
@@ -111,7 +132,10 @@ ingester prometheus_remote_write module {
 
 
   gauge "timestamp_lag" {
-    unit = "seconds"
+    index       = 7
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
 
     source prometheus "timestamp_lag" {
       query = "max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{}[1m]) - ignoring(remote_name, url) group_right max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{}[1m])"
@@ -122,7 +146,10 @@ ingester prometheus_remote_write module {
   }
 
   gauge "available_shards" {
-    unit = "count"
+    index       = 9
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "AVG"
 
     source prometheus "available_shards" {
       query = "max by (pod) (max_over_time(prometheus_remote_storage_shards_max{}[1m])) - max by (pod) (max_over_time(prometheus_remote_storage_shards_desired{}[1m]))"


### PR DESCRIPTION
Add index, input_unit and output_unit to all aws modules so that we can
automatically generate the components using the IOX init command