### PR TITLE
Use new index for new ec2 metrics

### DIFF
--- a/modules/aws/cloudstream/ec2.hcl
+++ b/modules/aws/cloudstream/ec2.hcl
@@ -46,6 +46,21 @@ ingester aws_ec2_cloudstream module {
     }
   }
 
+  gauge "cpu_credit_balance" {
+    index       = 2
+    input_unit  = "count"
+    output_unit = "count"
+    aggregator  = "MIN"
+
+    source prometheus "cpu_balance" {
+      query = "sum by (InstanceId) (amazonaws_com_AWS_EC2_CPUCreditBalance{InstanceId=~'$input{InstanceId}', quantile='0'})"
+
+      join_on = {
+        "$output{InstanceId}" = "$input{InstanceId}"
+      }
+    }
+  }
+
   gauge "network_in" {
     index       = 5
     input_unit  = "bytes"
@@ -91,23 +106,8 @@ ingester aws_ec2_cloudstream module {
     }
   }
 
-  gauge "cpu_credit_balance" {
-    index       = 2
-    input_unit  = "count"
-    output_unit = "count"
-    aggregator  = "MIN"
-
-    source prometheus "cpu_balance" {
-      query = "sum by (InstanceId) (amazonaws_com_AWS_EC2_CPUCreditBalance{InstanceId=~'$input{InstanceId}', quantile='0'})"
-
-      join_on = {
-        "$output{InstanceId}" = "$input{InstanceId}"
-      }
-    }
-  }
-
   gauge "ebs_io_balance" {
-    index       = 3
+    index       = 8
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MIN"
@@ -122,7 +122,7 @@ ingester aws_ec2_cloudstream module {
   }
 
   gauge "ebs_byte_balance" {
-    index       = 3
+    index       = 9
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "MIN"
@@ -137,7 +137,7 @@ ingester aws_ec2_cloudstream module {
   }
 
   gauge "cpu_surplus_credits_charged" {
-    index       = 3
+    index       = 11
     input_unit  = "count"
     output_unit = "count"
     aggregator  = "SUM"


### PR DESCRIPTION
```
select perform_action_on_component('overwrite', 'ec2_instance', 'physical', '{"cpu":{"aggregator":"AVG","index":"1","input_unit":"percent","output_unit":"percent","type":"gauge"},"cpu_credit_balance":{"aggregator":"MIN","index":"2","input_unit":"count","output_unit":"count","type":"gauge"},"cpu_surplus_credits_charged":{"aggregator":"SUM","index":"11","input_unit":"count","output_unit":"count","type":"gauge"},"ebs_byte_balance":{"aggregator":"MIN","index":"9","input_unit":"count","output_unit":"count","type":"gauge"},"ebs_io_balance":{"aggregator":"MIN","index":"8","input_unit":"count","output_unit":"count","type":"gauge"},"network_in":{"aggregator":"SUM","index":"5","input_unit":"bytes","output_unit":"Bps","type":"gauge"},"network_out":{"aggregator":"SUM","index":"6","input_unit":"bytes","output_unit":"Bps","type":"gauge"},"status_check_failed":{"aggregator":"SUM","index":"7","input_unit":"count","output_unit":"count","type":"gauge"}}', NULL, 'ec2_instance', NULL, NULL);
select perform_action_on_component('overwrite', 'rds', 'physical', '{"network_in":{"aggregator":"AVG","index":"1","input_unit":"bps","output_unit":"bps","type":"gauge"},"network_out":{"aggregator":"AVG","index":"2","input_unit":"bps","output_unit":"bps","type":"gauge"}}', NULL, 'rds', NULL, NULL);
```