### PR TITLE
[WIP] Fix datalake mofules

### DIFF
--- a/modules/datalake/aws/cloudfront.hcl
+++ b/modules/datalake/aws/cloudfront.hcl
@@ -9,7 +9,7 @@ ingester aws_cloudfront module {
     default = "$input{using}"
   }
 
-  inputs = "$input{inputs}"
+  inputs = "[]"
 
   label {
     type = "service"
@@ -18,17 +18,17 @@ ingester aws_cloudfront module {
 
   label {
     type = "namespace"
-    name = "$output{domain}"
+    name = "$output{tag_namespace}"
   }
 
   physical_component {
-    type = "cloudfront_distribution"
-    name = "$input{DistributionId}"
+    type = "cloudfront_distribution_physical"
+    name = "CLOUDFRONT_DISTRIBUTION"
   }
 
   data_for_graph_node {
     type = "cloudfront_distribution"
-    name = "$input{DistributionId}"
+    name = "$output{DistributionId}"
   }
 
   gauge "status_5xx" {
@@ -38,12 +38,7 @@ ingester aws_cloudfront module {
     aggregator  = "SUM"
 
     source prometheus "status_5xx" {
-      query = "sum by (DistributionId, Region, tag_domain, tag_service) (status_5xx)"
-
-      join_on = {
-        "$output{DistributionId}" = "$input{DistributionId}"
-        "$output{Region}"         = "$input{Region}"
-      }
+      query = "sum by (DistributionId, Region, tag_namespace, tag_service) (status_5xx{DistributionId!=''})"
     }
   }
 
@@ -54,12 +49,7 @@ ingester aws_cloudfront module {
     aggregator  = "SUM"
 
     source prometheus "status_4xx" {
-      query = "sum by (DistributionId, Region, tag_domain, tag_service) (status_4xx)"
-
-      join_on = {
-        "$output{DistributionId}" = "$input{DistributionId}"
-        "$output{Region}"         = "$input{Region}"
-      }
+      query = "sum by (DistributionId, Region, tag_namespace, tag_service) (status_4xx{DistributionId!=''})"
     }
   }
 
@@ -70,12 +60,7 @@ ingester aws_cloudfront module {
     aggregator  = "SUM"
 
     source prometheus "bytes_out" {
-      query = "sum by (DistributionId, Region, tag_domain, tag_service) (bytes_out)"
-
-      join_on = {
-        "$output{DistributionId}" = "$input{DistributionId}"
-        "$output{Region}"         = "$input{Region}"
-      }
+      query = "sum by (DistributionId, Region, tag_namespace, tag_service) (bytes_out{DistributionId!=''})"
     }
   }
 
@@ -86,12 +71,7 @@ ingester aws_cloudfront module {
     aggregator  = "SUM"
 
     source prometheus "bytes_in" {
-      query = "sum by (DistributionId, Region, tag_domain, tag_service) (bytes_in)"
-
-      join_on = {
-        "$output{DistributionId}" = "$input{DistributionId}"
-        "$output{Region}"         = "$input{Region}"
-      }
+      query = "sum by (DistributionId, Region, tag_namespace, tag_service) (bytes_in{DistributionId!=''})"
     }
   }
 
@@ -102,12 +82,7 @@ ingester aws_cloudfront module {
     aggregator  = "SUM"
 
     source prometheus "throughput" {
-      query = "sum by (DistributionId, Region, tag_domain, tag_service) (throughput)"
-
-      join_on = {
-        "$output{DistributionId}" = "$input{DistributionId}"
-        "$output{Region}"         = "$input{Region}"
-      }
+      query = "sum by (DistributionId, Region, tag_namespace, tag_service) (throughput{DistributionId!=''})"
     }
   }
 }

--- a/modules/datalake/aws/elasticcache.hcl
+++ b/modules/datalake/aws/elasticcache.hcl
@@ -1,4 +1,4 @@
-ingester aws_elasticache_redis module {
+ingester aws_elasticache module {
   frequency  = 60
   lookback   = 600
   timeout    = 30
@@ -18,7 +18,7 @@ ingester aws_elasticache_redis module {
   }
 
   physical_component {
-    type = "elasticache_cluster"
+    type = "elasticache_physical"
     name = "ELASTICACHE_CLUSTER"
   }
 
@@ -28,7 +28,7 @@ ingester aws_elasticache_redis module {
   }
 
   data_for_graph_node {
-    type = "elasticache_database"
+    type = "elasticache"
     name = "$output{CacheClusterId}"
   }
 
@@ -113,71 +113,8 @@ ingester aws_elasticache_redis module {
     }
   }
 
-  latency "latency_histo" {
-    error_margin = 0.05
-    index        = 6
-    input_unit   = "ms"
-    output_unit  = "ms"
-    aggregator   = "PERCENTILE"
-    multiplier   = 0.001
-
-    source prometheus "throughput" {
-      query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency_histo{le='throughput',CacheClusterId!='',CacheNodeId!=''})"
-    }
-
-    source prometheus "p50" {
-      query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency_histo{le='p50',CacheClusterId!='',CacheNodeId!=''})"
-    }
-
-    source prometheus "p75" {
-      query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency_histo{le='p75',CacheClusterId!='',CacheNodeId!=''})"
-    }
-
-    source prometheus "p90" {
-      query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency_histo{le='p90',CacheClusterId!='',CacheNodeId!=''})"
-    }
-
-    source prometheus "p99" {
-      query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency_histo{le='p99',CacheClusterId!='',CacheNodeId!=''})"
-    }
-  }
-}
-
-ingester aws_elasticache_cluster module {
-  frequency  = 60
-  lookback   = 600
-  timeout    = 30
-  resolution = 60
-  lag        = 60
-
-  inputs = "[]"
-
-  label {
-    type = "service"
-    name = "$output{tag_service}"
-  }
-
-  label {
-    type = "namespace"
-    name = "$output{tag_namespace}"
-  }
-
-  physical_component {
-    type = "elasticache_cluster"
-    name = "ELASTICACHE_CLUSTER"
-  }
-
-  data_for_graph_node {
-    type = "elasticache_cluster_logical"
-    name = "$output{CacheClusterId}"
-  }
-
-  using = {
-    "default" = "$input{using}"
-  }
-
   gauge "replication_lag" {
-    index       = 4
+    index       = 8
     input_unit  = "s"
     output_unit = "s"
     aggregator  = "MAX"
@@ -188,7 +125,7 @@ ingester aws_elasticache_cluster module {
   }
 
   gauge "bytes_out" {
-    index       = 2
+    index       = 9
     input_unit  = "bytes"
     output_unit = "bps"
     aggregator  = "SUM"
@@ -199,7 +136,7 @@ ingester aws_elasticache_cluster module {
   }
 
   gauge "bytes_in" {
-    index       = 3
+    index       = 11
     input_unit  = "bytes"
     output_unit = "bps"
     aggregator  = "SUM"
@@ -210,7 +147,7 @@ ingester aws_elasticache_cluster module {
   }
 
   gauge "cpu_used" {
-    index       = 1
+    index       = 12
     input_unit  = "percent"
     output_unit = "percent"
     aggregator  = "AVG"
@@ -221,13 +158,46 @@ ingester aws_elasticache_cluster module {
   }
 
   gauge "memory_used" {
-    index       = 5
+    index       = 13
     input_unit  = "percent"
     output_unit = "percent"
     aggregator  = "AVG"
 
     source prometheus "memory_used" {
       query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (memory_used{CacheClusterId!='',CacheNodeId!=''})"
+    }
+  }
+
+  gauge "latency_min" {
+    index       = 14
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MIN"
+
+    source prometheus "latency_min" {
+      query = "min by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency{stat='min',CacheClusterId!='',CacheNodeId!=''})"
+    }
+  }
+
+  gauge "latency_avg" {
+    index       = 15
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "AVG"
+
+    source prometheus "latency_avg" {
+      query = "avg by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency{stat='avg',CacheClusterId!='',CacheNodeId!=''})"
+    }
+  }
+
+  gauge "latency_max" {
+    index       = 16
+    input_unit  = "s"
+    output_unit = "s"
+    aggregator  = "MAX"
+
+    source prometheus "latency_max" {
+      query = "max by (CacheClusterId, CacheNodeId, tag_namespace, tag_service) (latency{stat='max',CacheClusterId!='',CacheNodeId!=''})"
     }
   }
 }


### PR DESCRIPTION
  
#### Elasticache

  * Merge physical and logical view is such a way that the all the
    metrics appear in the logical view and nothing in physical view
  * Remove latency_histo and use regilar gauges for latency min, max and
    avg

#### Cloudfront

  * Suffix physical component type with `_physical`. This will make the physical component type different from `data_for` type, allowing us to make the physical component name static and `data_for` name dynamic

## This is a WIP. Do not merge